### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Some hints on changes to this repository
+
+### Public information only
+
+This is a public repository. The content and commit history is visible to everyone.
+
+Do not provide any **customer-specific details**. Use the customer's repository for that.
+
+### Descriptive PR title
+
+Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.


### PR DESCRIPTION
This PR adds a PR template that highlights two things to be aware of:

- Public repo for public info only
- Descriptive PR titles

So far there is no info related to automation yet, but this might get added in the future.