### PR TITLE
Enable Provider Families for AWS

### DIFF
--- a/extras/crossplane/kustomization.yaml
+++ b/extras/crossplane/kustomization.yaml
@@ -4,4 +4,3 @@ resources:
 - namespace-crossplane.yaml
 - podmonitor-crossplane.yaml
 - providers-kustomization.yaml
-- service-account.yaml

--- a/extras/crossplane/providers/upbound/aws/README.md
+++ b/extras/crossplane/providers/upbound/aws/README.md
@@ -54,7 +54,7 @@ patches:
       - op: replace
         path: /spec/controllerConfigRef/name
         value: provider-aws-${PROVIDER}
-      - op: replace
+      - op: add
         path: /spec/package
         value: xpkg.upbound.io/upbound/provider-aws-${PROVIDER}:v0.37.0
     target:

--- a/extras/crossplane/providers/upbound/aws/README.md
+++ b/extras/crossplane/providers/upbound/aws/README.md
@@ -53,7 +53,7 @@ patches:
         value: provider-aws-${PROVIDER}
       - op: replace
         path: /spec/controllerConfigRef/name
-        value: provider-aws-PROIVIDER
+        value: provider-aws-${PROVIDER}
       - op: replace
         path: /spec/package
         value: xpkg.upbound.io/upbound/provider-aws-${PROVIDER}:v0.37.0

--- a/extras/crossplane/providers/upbound/aws/README.md
+++ b/extras/crossplane/providers/upbound/aws/README.md
@@ -1,0 +1,84 @@
+# Enabling providers and provider family members
+
+> **Note** These providers are not intended to be installed directly.
+>
+With the changes to `crossplane` brought about in version v1.12.0, GiantSwarm
+will no longer be directly managing providers but instead we'll be offering a
+simplified process to installing new providers inside your cluster.
+
+For the moment this is limited to the major cloud providers
+
+- upbound-provider-aws
+- upbound-provider-azure
+- upbound-provider-gcp
+
+We currently do not support the community contributed providers. If you have a
+use case for this, or for another provider, we encourage you to talk to us first.
+
+## Provider installation
+
+In the git repository relating to your management cluster, you will find a
+folder `crossplane-providers`. If this does not exist let us know and crossplane
+will be enabled for you.
+
+Inside this folder, create a subfolder with the API group of the family you
+wish to install. For example, if you want to install `ec2.aws.upbound.io` then
+the directory will be called simply `ec2`.
+
+Edit the following `Kustomization` and change all instances of `${PROVIDER}` to
+match the directory name. Save this inside the provider directory as
+`kustomization.yaml`
+
+> **Warning** This example is for AWS only. For Azure and GCP make sure you
+> adapt the provider names and annotations accordingly
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/giantswarm/management-cluster-bases//extras/crossplane/providers/upbound/aws?ref=main
+patches:
+  - patch: |
+      - op: replace
+        path: /metadata/name
+        value: provider-aws-${PROVIDER}
+      - op: replace
+        path: /spec/serviceAccountName
+        value: upbound-provider-aws-${PROVIDER}
+    target:
+      kind: ControllerConfig
+  - patch: |
+      - op: replace
+        path: /metadata/name
+        value: provider-aws-${PROVIDER}
+      - op: replace
+        path: /spec/controllerConfigRef/name
+        value: provider-aws-PROIVIDER
+      - op: replace
+        path: /spec/package
+        value: xpkg.upbound.io/upbound/provider-aws-${PROVIDER}:v0.37.0
+    target:
+      kind: Provider
+  - patch: |
+      - op: replace
+        path: /metadata/name
+        value: upbound-provider-aws-${PROVIDER}
+      - op: add
+        path: /metadata/annotations/eks.amazonaws.com~1role-arn
+        value: arn:aws:iam::${AWS_ACCOUNT_ID}:role/crossplane-assume-role
+    target:
+      kind: ServiceAccount
+  - patch: |
+     - op: replace
+       path: /metadata/name
+       value: crossplane-use-psp-upbound-provider-aws-${PROVIDER}
+     - op: replace
+       path: /subjects/0/name
+       value: upbound-provider-aws-${PROVIDER}
+    target:
+      kind: ClusterRoleBinding
+```
+
+For setup and configuration of IAM, please see the example documentation in the
+[crossplane-examples](https://github.com/giantswarm/crossplane-examples/blob/add-aws-crossplane/aws-provider/postgresdb/README.md)
+repo.

--- a/extras/crossplane/providers/upbound/aws/controller-config.yaml
+++ b/extras/crossplane/providers/upbound/aws/controller-config.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   args:
     - --debug
-  serviceAccountName: upbound-provider
+  serviceAccountName: "replaced by kustomization"

--- a/extras/crossplane/providers/upbound/aws/kustomization.yaml
+++ b/extras/crossplane/providers/upbound/aws/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - controller-config.yaml
 - provider.yaml
+- service-account.yaml

--- a/extras/crossplane/providers/upbound/aws/provider.yaml
+++ b/extras/crossplane/providers/upbound/aws/provider.yaml
@@ -8,7 +8,6 @@ spec:
   controllerConfigRef:
     name: upbound-provider-aws
   ignoreCrossplaneConstraints: false
-  package: xpkg.upbound.io/upbound/provider-aws:v0.35.0
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 0

--- a/extras/crossplane/providers/upbound/aws/service-account.yaml
+++ b/extras/crossplane/providers/upbound/aws/service-account.yaml
@@ -2,8 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: upbound-provider
+  name: "replaced by kustomization"
   namespace: crossplane
+  annotations: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -15,5 +16,5 @@ roleRef:
   name: crossplane-use-psp
 subjects:
 - kind: ServiceAccount
-  name: upbound-provider
+  name: "replaced by kustomization"
   namespace: crossplane

--- a/extras/crossplane/providers/upbound/azure/README.md
+++ b/extras/crossplane/providers/upbound/azure/README.md
@@ -30,7 +30,7 @@ patches:
       - op: replace
         path: /spec/controllerConfigRef/name
         value: provider-azure-${PROVIDER}
-      - op: replace
+      - op: add
         path: /spec/package
         value: xpkg.upbound.io/upbound/provider-azure-${PROVIDER}:v0.37.0
     target:

--- a/extras/crossplane/providers/upbound/azure/README.md
+++ b/extras/crossplane/providers/upbound/azure/README.md
@@ -1,0 +1,59 @@
+# Enabling providers and provider family members for Azure
+
+Please see [service account labels and annotations](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)
+for a full set of annotations that may be used on Azure
+
+## Example `Kustomization`
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/giantswarm/management-cluster-bases//extras/crossplane/providers/upbound/azure?ref=main
+patches:
+  - patch: |
+      - op: replace
+        path: /metadata/name
+        value: provider-azure-${PROVIDER}
+      - op: replace
+        path: /spec/serviceAccountName
+        value: upbound-provider-azure-${PROVIDER}
+      - op: add
+        path: /spec/metadata/annotations/azure.workload.identity~1use
+        value: true
+    target:
+      kind: ControllerConfig
+  - patch: |
+      - op: replace
+        path: /metadata/name
+        value: provider-azure-${PROVIDER}
+      - op: replace
+        path: /spec/controllerConfigRef/name
+        value: provider-azure-${PROVIDER}
+      - op: replace
+        path: /spec/package
+        value: xpkg.upbound.io/upbound/provider-azure-${PROVIDER}:v0.37.0
+    target:
+      kind: Provider
+  - patch: |
+      - op: replace
+        path: /metadata/name
+        value: upbound-provider-azure-${PROVIDER}
+      - op: add
+        path: /metadata/annotations/azure.workload.identity~1client-id
+        value: REPLACE_ME_WITH_CLIENT_ID
+      - op: add
+        path: /metadata/annotations/azure.workload.identity~1tenant-id
+        value: REPLACE_ME_WITH_TENANT_ID
+    target:
+      kind: ServiceAccount
+  - patch: |
+     - op: replace
+       path: /metadata/name
+       value: crossplane-use-psp-upbound-provider-azure-${PROVIDER}
+     - op: replace
+       path: /subjects/0/name
+       value: upbound-provider-azure-${PROVIDER}
+    target:
+      kind: ClusterRoleBinding
+```

--- a/extras/crossplane/providers/upbound/azure/controller-config.yaml
+++ b/extras/crossplane/providers/upbound/azure/controller-config.yaml
@@ -8,3 +8,6 @@ spec:
   args:
     - --debug
   serviceAccountName: upbound-provider
+  metadata:
+    annotations: {}
+    labels: {}

--- a/extras/crossplane/providers/upbound/azure/kustomization.yaml
+++ b/extras/crossplane/providers/upbound/azure/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - controller-config.yaml
 - provider.yaml
+- service-account.yaml

--- a/extras/crossplane/providers/upbound/azure/provider.yaml
+++ b/extras/crossplane/providers/upbound/azure/provider.yaml
@@ -8,7 +8,6 @@ spec:
   controllerConfigRef:
     name: upbound-provider-azure
   ignoreCrossplaneConstraints: false
-  package: xpkg.upbound.io/upbound/provider-azure:v0.33.0
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 0

--- a/extras/crossplane/providers/upbound/azure/service-account.yaml
+++ b/extras/crossplane/providers/upbound/azure/service-account.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: upbound-provider-azure
+  namespace: crossplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-use-psp-upbound-provider-azure
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-use-psp
+subjects:
+- kind: ServiceAccount
+  name: upbound-provider-azure
+  namespace: crossplane

--- a/extras/crossplane/providers/upbound/gcp/kustomization.yaml
+++ b/extras/crossplane/providers/upbound/gcp/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - controller-config.yaml
 - provider.yaml
+- service-account.yaml

--- a/extras/crossplane/providers/upbound/gcp/provider.yaml
+++ b/extras/crossplane/providers/upbound/gcp/provider.yaml
@@ -8,7 +8,6 @@ spec:
   controllerConfigRef:
     name: upbound-provider-gcp
   ignoreCrossplaneConstraints: false
-  package: xpkg.upbound.io/upbound/provider-gcp:v0.33.0
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 0

--- a/extras/crossplane/providers/upbound/gcp/service-account.yaml
+++ b/extras/crossplane/providers/upbound/gcp/service-account.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: upbound-provider-gcp
+  namespace: crossplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-use-psp-upbound-provider-gcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-use-psp
+subjects:
+- kind: ServiceAccount
+  name: upbound-provider-gcp
+  namespace: crossplane


### PR DESCRIPTION
## Some hints on changes to this repository

This PR re-introduces the individual provider service accounts but in a manner where it is required that for AWS provider, they are patched according to the documentation at [extras/crossplane/providers/upbound/aws/README.md](https://github.com/giantswarm/management-cluster-bases/blob/crossplane-individual-sa/extras/crossplane/providers/upbound/aws/README.md)

There should be no change or effect on Azure or GCP providers at this moment as the move to provider-families may have a detrimental effect on existing clusters prior to them being migrated.