### PR TITLE
Restore MCB related make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bin
+output

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl@6.1.1
+#
+
+include Makefile.*.mk
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z%\\\/_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,0 +1,74 @@
+# Check https://github.com/fluxcd/flux2/blob/main/.github/runners/prereq.sh if
+# you're updating kustomize versions.
+KUSTOMIZE := ./bin/kustomize
+KUSTOMIZE_VERSION ?= v4.5.7
+
+YQ := ./bin/yq
+YQ_VERSION := 4.31.2
+
+FLUX_APP_REPOSITORY := https://giantswarm.github.io/giantswarm-catalog/
+FLUX_APP_VERSION := v0.23.1
+FLUX_VERSION := v0.41.2
+
+KONFIGURE_IMAGE_TAG := 0.14.4
+KUSTOMIZE_CONTROLLER_IMAGE_TAG := v0.35.1
+
+GNU_SED := $(shell sed --version 1>/dev/null 2>&1; echo $$?)
+OS ?= $(shell go env GOOS 2>/dev/null || echo linux)
+ARCH ?= $(shell go env GOARCH 2>/dev/null || echo amd64)
+
+.PHONY: all
+all: ensure-versions
+
+.PHONY: ensure-versions
+ensure-versions: $(YQ) download-upstream-crds
+	@echo "====> $@"
+	head output/flux-$(FLUX_VERSION).crds.yaml
+	cp output/flux-$(FLUX_VERSION).crds.yaml bases/flux-app/crds/crds.yaml
+	head bases/flux-app/crds/crds.yaml
+
+ifeq ($(GNU_SED),0)
+	sed -i "0,/version:/{s!repo: .*!repo: $(FLUX_APP_REPOSITORY)!g}" bases/flux-app/customer/kustomization.yaml
+	sed -i "0,/version:/{s!repo: .*!repo: $(FLUX_APP_REPOSITORY)!g}" bases/flux-app/giantswarm/kustomization.yaml
+
+	sed -i "0,/version:/{s/version: .*/version: $(FLUX_APP_VERSION)/g}" bases/flux-app/customer/kustomization.yaml
+	sed -i "0,/version:/{s/version: .*/version: $(FLUX_APP_VERSION)/g}" bases/flux-app/giantswarm/kustomization.yaml
+
+	sed -i "0,/image: giantswarm\/konfigure/{s/giantswarm\/konfigure:.*/giantswarm\/konfigure:$(KONFIGURE_IMAGE_TAG)/g}" bases/flux-app/giantswarm/patch-kustomize-controller.yaml
+	sed -i "0,/image: giantswarm\/kustomize-controller/{s/giantswarm\/kustomize-controller:.*/giantswarm\/kustomize-controller:$(KUSTOMIZE_CONTROLLER_IMAGE_TAG)/g}" bases/flux-app/giantswarm/patch-kustomize-controller.yaml
+else
+	sed -i "" "1,/version:/ s/version: .*/version: $(FLUX_APP_VERSION)/g" bases/flux-app/customer/kustomization.yaml
+	sed -i "" "1,/version:/ s/version: .*/version: $(FLUX_APP_VERSION)/g" bases/flux-app/giantswarm/kustomization.yaml
+
+	sed -i "" "1,/image: giantswarm\/konfigure/ s/giantswarm\/konfigure:.*/giantswarm\/konfigure:$(KONFIGURE_IMAGE_TAG)/g" bases/flux-app/giantswarm/patch-kustomize-controller.yaml
+	sed -i "" "1,/image: giantswarm\/kustomize-controller/ s/giantswarm\/kustomize-controller:.*/giantswarm\/kustomize-controller:$(KUSTOMIZE_CONTROLLER_IMAGE_TAG)/g" bases/flux-app/giantswarm/patch-kustomize-controller.yaml
+endif
+	git clean -fxd bases/flux-app/
+
+.PHONY: build-catalogs-with-defaults
+build-catalogs-with-defaults: $(KUSTOMIZE) ## Build Giant Swarm catalogs with default configuration
+	@echo "====> $@"
+	mkdir -p output
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone bases/catalogs -o output/catalogs-with-defaults.yaml
+
+
+$(KUSTOMIZE): ## Download kustomize locally if necessary.
+	@echo "====> $@"
+	mkdir -p $(dir $@)
+	curl -sfL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$(OS)_$(ARCH).tar.gz" | tar zxv -C $(dir $@)
+	chmod +x $@
+
+$(YQ): ## Download yq locally if necessary.
+	@echo "====> $@"
+	mkdir -p $(dir $@)
+	curl -sfL https://github.com/mikefarah/yq/releases/download/v$(YQ_VERSION)/yq_$(OS)_$(ARCH) > $@
+	chmod +x $@
+
+download-upstream-install:
+	@echo "====> $@"
+	mkdir -p output
+	curl -sfL "https://github.com/fluxcd/flux2/releases/download/$(FLUX_VERSION)/install.yaml" > output/flux-$(FLUX_VERSION).install.yaml
+
+download-upstream-crds: download-upstream-install $(YQ)
+	@echo "====> $@"
+	$(YQ) eval-all 'select(.kind == "CustomResourceDefinition")' output/flux-$(FLUX_VERSION).install.yaml > output/flux-$(FLUX_VERSION).crds.yaml

--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ To learn more about how GitOps works with Giant Swarm, check our [GitOps documen
   - `flux-giantswarm-resources`: resources created in the `flux-giantswarm` namespace during the management cluster bootstrapping process
   - `provider`: definitions for all the infrastructure providers we serve.
 - `extras`: collection of patches, additional resources, and mix-ins used by several management clusters.
+
+## Tools
+
+In order to upgrade Flux App and `konfigure` bump the versions in `Makefile.custom.mk` and run the following command:
+
+```shell
+make ensure-versions
+```
+
+To build the catalogs with their default values:
+
+```shell
+make build-catalogs-with-defaults
+```

--- a/bases/tools/Makefile.custom.mk
+++ b/bases/tools/Makefile.custom.mk
@@ -107,12 +107,3 @@ $(YQ): ## Download yq locally if necessary.
 	mkdir -p $(dir $@)
 	curl -sfL https://github.com/mikefarah/yq/releases/download/v$(YQ_VERSION)/yq_$(OS)_$(ARCH) > $@
 	chmod +x $@
-
-download-upstream-install:
-	@echo "====> $@"
-	mkdir -p output
-	curl -sfL "https://github.com/fluxcd/flux2/releases/download/$(FLUX_VERSION)/install.yaml" > output/flux-$(FLUX_VERSION).install.yaml
-
-download-upstream-crds: download-upstream-install $(YQ)
-	@echo "====> $@"
-	$(YQ) eval-all 'select(.kind == "CustomResourceDefinition")' output/flux-$(FLUX_VERSION).install.yaml > output/flux-$(FLUX_VERSION).crds.yaml


### PR DESCRIPTION
This PR restores bumping `flux-app` and `konfigure` versions and some other makefile targets that make sense on MCB itself, like building catalogs with default values.