### PR TITLE
Extend list of common GS CRDs based on apiextensions/crds-common helm chart + pin version

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -1,6 +1,15 @@
 resources:
-  - https://raw.githubusercontent.com/giantswarm/apiextensions-application/master/config/crd/application.giantswarm.io_appcatalogentries.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions-application/master/config/crd/application.giantswarm.io_appcatalogs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions-application/master/config/crd/application.giantswarm.io_apps.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions-application/master/config/crd/application.giantswarm.io_catalogs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions-application/master/config/crd/application.giantswarm.io_charts.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_appcatalogentries.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_appcatalogs.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_apps.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_catalogs.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_charts.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_certconfigs.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_chartconfigs.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_configs.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_drainerconfigs.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_sparks.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_storageconfigs.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/monitoring.giantswarm.io_silences.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/release.giantswarm.io_releases.yaml
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/security.giantswarm.io_organizations.yaml


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27731

Related to: https://github.com/giantswarm/rfc/pull/73 (This is gonna be needed anyway)

Decided to go with a pinned version because of this thread: https://github.com/giantswarm/rfc/pull/71#discussion_r1280399122

