### PR TITLE
add rolebindingtemplates to giantswarm crd

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - https://raw.githubusercontent.com/giantswarm/apiextensions-application/master/config/crd/application.giantswarm.io_apps.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions-application/master/config/crd/application.giantswarm.io_catalogs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions-application/master/config/crd/application.giantswarm.io_charts.yaml
+  - https://raw.githubusercontent.com/giantswarm/rbac-operator/main/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2709
This adds the new RoleBindingTemplate CRD which is not yet installed on our installations. (rbac-operator is yet to be released as well) Guidance on other needed steps to roll this out are welcome.

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
