### PR TITLE
Add trailing dot in FQDN for NTPServers

### DIFF
--- a/bases/catalogs/giantswarm/appcatalog-default-test.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-default-test.yaml
@@ -62,4 +62,4 @@ spec:
                 TCP:
                   Disabled: false
               Hosts: "giantswarm.io.,kubernetes.default.svc.cluster.local."
-              NTPServers: "0.flatcar.pool.ntp.org,1.flatcar.pool.ntp.org"
+              NTPServers: "0.flatcar.pool.ntp.org,1.flatcar.pool.ntp.org."

--- a/bases/catalogs/giantswarm/appcatalog-default.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-default.yaml
@@ -62,7 +62,7 @@ spec:
                 TCP:
                   Disabled: false
               Hosts: "giantswarm.io.,kubernetes.default.svc.cluster.local."
-              NTPServers: "0.flatcar.pool.ntp.org,1.flatcar.pool.ntp.org"
+              NTPServers: "0.flatcar.pool.ntp.org,1.flatcar.pool.ntp.org."
             # Mitigate rate limiting issues for external-dns
             externalDNS:
               interval: 5m


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

This is used by net-exporter to generating synthetic traffic/probes. Adding the trailing dot removes the need for domain search, resulting in a faster response.

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
