### PR TITLE
deploy and test grafana on imported eks

### DIFF
--- a/bases/provider/eks/helmrelease/grafana/README.md
+++ b/bases/provider/eks/helmrelease/grafana/README.md
@@ -1,0 +1,3 @@
+# Metrics server
+
+Deploys Giant Swarm's Grafana.

--- a/bases/provider/eks/helmrelease/grafana/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/grafana/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: sample-customer-grafana
+  namespace: org-sample
+spec:
+  releaseName: grafana
+  targetNamespace: kube-system
+  storageNamespace: kube-system
+  kubeConfig:
+    secretRef:
+      name: sample-customer-kubeconfig
+  chart:
+    spec:
+      chart: grafana
+      version: 6.59.4
+      sourceRef:
+        kind: HelmRepository
+        name: giantswarm-default-catalog
+  interval: 50m
+  install:
+    remediation:
+      retries: 3

--- a/bases/provider/eks/helmrelease/grafana/kustomization.yaml
+++ b/bases/provider/eks/helmrelease/grafana/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2888

Deploying `grafana` to an imported EKS cluster to test everything is working as expected.
