### PR TITLE
Script to check for Flux v2 deprecated fields and remove apiVersion patches for gitrepos and kustomizations

### DIFF
--- a/bases/provider/aws-china/flux-v2/kustomization.yaml
+++ b/bases/provider/aws-china/flux-v2/kustomization.yaml
@@ -1,26 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
   - path: patch-helm-controller.yaml
   - path: patch-kustomize-controller.yaml
   - path: patch-source-controller.yaml

--- a/bases/provider/aws/flux-v2/kustomization.yaml
+++ b/bases/provider/aws/flux-v2/kustomization.yaml
@@ -1,26 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
 replacements:
   # Points collection GitRepository to correct URL
   - source:

--- a/bases/provider/azure/flux-v2/kustomization.yaml
+++ b/bases/provider/azure/flux-v2/kustomization.yaml
@@ -1,26 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
 replacements:
   # Points collection GitRepository to correct URL
   - source:

--- a/bases/provider/capa/flux-v2/kustomization.yaml
+++ b/bases/provider/capa/flux-v2/kustomization.yaml
@@ -1,26 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
 replacements:
   # Points collection GitRepository to correct URL
   - source:

--- a/bases/provider/capz/flux-v2/kustomization.yaml
+++ b/bases/provider/capz/flux-v2/kustomization.yaml
@@ -1,26 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
 replacements:
   # Points collection GitRepository to correct URL
   - source:

--- a/bases/provider/cloud-director/flux-v2/kustomization.yaml
+++ b/bases/provider/cloud-director/flux-v2/kustomization.yaml
@@ -1,26 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
 replacements:
   # Points collection GitRepository to correct URL
   - source:

--- a/bases/provider/gcp/flux-v2/kustomization.yaml
+++ b/bases/provider/gcp/flux-v2/kustomization.yaml
@@ -1,26 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
 replacements:
   # Points collection GitRepository to correct URL
   - source:

--- a/bases/provider/kvm/flux-v2/kustomization.yaml
+++ b/bases/provider/kvm/flux-v2/kustomization.yaml
@@ -1,26 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
 replacements:
   # Points collection GitRepository to correct URL
   - source:

--- a/bases/provider/openstack/flux-v2/kustomization.yaml
+++ b/bases/provider/openstack/flux-v2/kustomization.yaml
@@ -1,26 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
 replacements:
   # Points collection GitRepository to correct URL
   - source:

--- a/bases/provider/vsphere/flux-v2/kustomization.yaml
+++ b/bases/provider/vsphere/flux-v2/kustomization.yaml
@@ -1,26 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
-#  - target:
-#      group: source.toolkit.fluxcd.io
-#      version: v1beta2
-#      kind: 'GitRepository'
-#      name: '.*'
-#      namespace: 'flux-giantswarm'
-#    patch: |-
-#      - op: replace
-#        path: "/apiVersion"
-#        value: source.toolkit.fluxcd.io/v1
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      version: v1beta2
-      kind: 'Kustomization'
-      name: '.*'
-      namespace: 'flux-giantswarm'
-    patch: |-
-      - op: replace
-        path: "/apiVersion"
-        value: kustomize.toolkit.fluxcd.io/v1
   - target:
       kind: GitRepository
       name: collection

--- a/tools/flux-v2-deprecation/check.py
+++ b/tools/flux-v2-deprecation/check.py
@@ -1,0 +1,75 @@
+from io import StringIO
+
+import sh
+import yaml
+from termcolor import colored
+from yaml import FullLoader
+
+
+def main() -> None:
+    check_git_repositories()
+    print()
+    print("#" * 80)
+    print()
+    check_kustomizations()
+
+
+def check_git_repositories() -> None:
+    print("Checking gitrepositories.source.toolkit.fluxcd.io across all namespaces...")
+
+    buffer = StringIO()
+    sh.kubectl("get", "gitrepositories.source.toolkit.fluxcd.io", "-A", "-o", "yaml", _out=buffer)
+    git_repositories = yaml.load(buffer.getvalue(), Loader=FullLoader)
+
+    for git_repository in git_repositories['items']:
+        has_errors = False
+
+        print(f"# Checking: {git_repository['metadata']['namespace']}/{git_repository['metadata']['name']}")
+
+        git_implementation = git_repository['spec'].get('gitImplementation')
+        if git_implementation:
+            if git_implementation == "go-git":
+                print(colored(f"  > Warning! .spec.gitImplementation is set to: {git_implementation}", "yellow"))
+            else:
+                has_errors = True
+                print(colored(f"  > Failed! .spec.gitImplementation is set to: {git_implementation}", "red"))
+
+        access_from = git_repository['spec'].get('accessFrom')
+        if access_from:
+            has_errors = True
+            print(colored(f"  > Failed! .spec.accessFrom is set to: {access_from}", "red"))
+
+        if not has_errors:
+            print(colored(f"  > Passed!", "green"))
+
+
+def check_kustomizations() -> None:
+    print("Checking kustomizations.kustomize.toolkit.fluxcd.io across all namespaces...")
+
+    buffer = StringIO()
+    sh.kubectl("get", "kustomizations.kustomize.toolkit.fluxcd.io", "-A", "-o", "yaml", _out=buffer)
+    kustomizations = yaml.load(buffer.getvalue(), Loader=FullLoader)
+
+    for kustomization in kustomizations['items']:
+        has_errors = False
+
+        print(f"# Checking: {kustomization['metadata']['namespace']}/{kustomization['metadata']['name']}")
+
+        if kustomization['spec'].get('validation'):
+            has_errors = True
+            print(colored(f"  > Failed! .spec.validation is set!", "red"))
+
+        if kustomization['spec'].get('patchesStrategicMerge'):
+            has_errors = True
+            print(colored(f"  > Failed! .spec.patchesStrategicMerge is set! Should be moved to .spec.patches!", "red"))
+
+        if kustomization['spec'].get('patchesJson6902'):
+            has_errors = True
+            print(colored(f"  > Failed! .spec.patchesJson6902 is set! Should be moved to .spec.patches!", "red"))
+
+        if not has_errors:
+            print(colored(f"  > Passed!", "green"))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/flux-v2-deprecation/requirements.txt
+++ b/tools/flux-v2-deprecation/requirements.txt
@@ -1,0 +1,3 @@
+sh==2.0.6
+pyyaml==6.0.1
+termcolor==2.3.0

--- a/tools/flux-v2-deprecation/setup.sh
+++ b/tools/flux-v2-deprecation/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT_PATH="$(cd -- "$(dirname "$0")" > /dev/null 2>&1 || exit ; pwd -P)"
+
+virtualenv -p python3 "${SCRIPT_PATH}/virtualenv"
+
+source "${SCRIPT_PATH}/virtualenv/bin/activate"
+
+"${SCRIPT_PATH}"/virtualenv/bin/pip install -r "${SCRIPT_PATH}/requirements.txt"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2648

Based on `API Changes` section of: https://github.com/fluxcd/flux2/releases/tag/v2.0.0

Decided not to check for `.status` field deprecations as those belong to the controllers anyway.