### PR TITLE
Use batch/v1 apiVersion instead of deprecated batch/v1beta1 for cronjobs

### DIFF
--- a/bases/flux-app-v2/giantswarm/resource-refresh-vault-token.yaml
+++ b/bases/flux-app-v2/giantswarm/resource-refresh-vault-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: refresh-vault-token

--- a/bases/flux-app/giantswarm/resource-refresh-vault-token.yaml
+++ b/bases/flux-app/giantswarm/resource-refresh-vault-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: refresh-vault-token

--- a/extras/vaultless/patch-delete-vault-cronjob.yaml
+++ b/extras/vaultless/patch-delete-vault-cronjob.yaml
@@ -1,5 +1,5 @@
 $patch: delete
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: refresh-vault-token


### PR DESCRIPTION
On k8s 1.25 using v1beta1 for cronjobs doesn't work any more:

```
cronJob/flux-giantswarm/refresh-vault-token dry-run failed, error: no matches for kind "CronJob" in version "batch/v1beta1"...
```

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
