### PR TITLE
change helm repo's ns for all helm releases in eks clusters

### DIFF
--- a/bases/provider/eks/helmrelease/grafana/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/grafana/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: giantswarm-catalog
-        namespace: flux-giantswarm
+        namespace: default
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/metrics-server/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/metrics-server/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: giantswarm-default-catalog
-        namespace: flux-giantswarm
+        namespace: default
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/observability-bundle/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/observability-bundle/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: giantswarm-default-catalog
-        namespace: flux-giantswarm
+        namespace: default
   interval: 50m
   install:
     remediation:
@@ -42,7 +42,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: giantswarm-default-catalog
-        namespace: flux-giantswarm
+        namespace: default
   interval: 50m
   install:
     remediation:
@@ -90,7 +90,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: giantswarm-default-catalog
-        namespace: flux-giantswarm
+        namespace: default
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/vertical-pod-autoscaler/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/vertical-pod-autoscaler/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: giantswarm-default-catalog
-        namespace: flux-giantswarm
+        namespace: default
   interval: 50m
   install:
     remediation:


### PR DESCRIPTION
Created a duplicate of the `giantswarm-catalog` and `giantswarm-default-catalog` helmrepository in the `default` ns in `snail` to be able to deploy grafana.
