### PR TITLE
Create kustomization for vaultless extra with single document patches

### DIFF
--- a/extras/vaultless/kustomization.yaml
+++ b/extras/vaultless/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+  - path: patch-delete-refresh-vault-token-cron-job.yaml
+  - path: patch-delete-refresh-vault-token-role.yaml
+  - path: patch-delete-refresh-vault-token-role-binding.yaml
+  - path: patch-delete-refresh-vault-token-service-account.yaml
+  - path: patch-kustomize-controller.yaml

--- a/extras/vaultless/patch-delete-refresh-vault-token-cron-job.yaml
+++ b/extras/vaultless/patch-delete-refresh-vault-token-cron-job.yaml
@@ -1,0 +1,6 @@
+$patch: delete
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: refresh-vault-token
+  namespace: flux-giantswarm

--- a/extras/vaultless/patch-delete-refresh-vault-token-role-binding.yaml
+++ b/extras/vaultless/patch-delete-refresh-vault-token-role-binding.yaml
@@ -1,0 +1,14 @@
+$patch: delete
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: refresh-vault-token
+  namespace: flux-giantswarm
+subjects:
+  - kind: ServiceAccount
+    name: refresh-vault-token
+    namespace: flux-giantswarm
+roleRef:
+  kind: Role
+  name: refresh-vault-token
+  apiGroup: rbac.authorization.k8s.io

--- a/extras/vaultless/patch-delete-refresh-vault-token-role.yaml
+++ b/extras/vaultless/patch-delete-refresh-vault-token-role.yaml
@@ -1,0 +1,10 @@
+$patch: delete
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: refresh-vault-token
+  namespace: flux-giantswarm
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "secrets"]
+    verbs: ["*"]

--- a/extras/vaultless/patch-delete-refresh-vault-token-service-account.yaml
+++ b/extras/vaultless/patch-delete-refresh-vault-token-service-account.yaml
@@ -1,0 +1,6 @@
+$patch: delete
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: refresh-vault-token
+  namespace: flux-giantswarm


### PR DESCRIPTION
As `kustomize` has a bug so that it cannot handle multi document patches under the `patches` entry in `kustomize` v5+ where `patchStrategicMerge` is deprecated.

