### PR TITLE
Bump `kustomize` to `v5.0.3` used by our current KC deployment and move back to `patchesStrategicMerge` because of upstream bug + how we render kustomizations locally

### DIFF
--- a/bases/flux-app-v2/giantswarm/kustomization.yaml
+++ b/bases/flux-app-v2/giantswarm/kustomization.yaml
@@ -157,8 +157,10 @@ patches:
         - --enable-leader-election
         - --storage-path=/data
         - "--storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc"
-- path: patch-pvc-psp.yaml
-- path: patch-kustomize-controller.yaml
+# Keeping this because of vaultless helper + upstream bug in kustomize to apply patch files with multiple documents
+patchesStrategicMerge:
+- patch-pvc-psp.yaml
+- patch-kustomize-controller.yaml
 resources:
 - resource-namespace.yaml
 - resource-rbac.yaml

--- a/bases/tools/Makefile.custom.mk
+++ b/bases/tools/Makefile.custom.mk
@@ -99,7 +99,7 @@ ifeq ($(FORCE_CRDS),1)
 	$(YQ) e -i '(.helmCharts[] | select(.name == "flux-app") | .valuesInline.crds.install) = true' $(TMP_BASE)/kustomization.yaml
 endif
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone --enable-helm --helm-command="$(HELM)" $(TMP_BASE) -o output/flux-app-v${FLUX_MAJOR_VERSION}-$(SUFFIX).yaml
-	#rm -rf $(TMP_BASE)
+	rm -rf $(TMP_BASE)
 
 .PHONY: $(BUILD_MC_TARGETS)
 $(BUILD_MC_TARGETS): $(KUSTOMIZE) $(HELM) $(YQ)

--- a/bases/tools/Makefile.custom.mk
+++ b/bases/tools/Makefile.custom.mk
@@ -1,7 +1,7 @@
 # Check https://github.com/fluxcd/flux2/blob/main/.github/runners/prereq.sh if
 # you're updating kustomize versions.
 KUSTOMIZE := ./bin/kustomize
-KUSTOMIZE_VERSION ?= v4.5.7
+KUSTOMIZE_VERSION ?= v5.0.3
 
 HELM := ./bin/helm
 
@@ -99,7 +99,7 @@ ifeq ($(FORCE_CRDS),1)
 	$(YQ) e -i '(.helmCharts[] | select(.name == "flux-app") | .valuesInline.crds.install) = true' $(TMP_BASE)/kustomization.yaml
 endif
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone --enable-helm --helm-command="$(HELM)" $(TMP_BASE) -o output/flux-app-v${FLUX_MAJOR_VERSION}-$(SUFFIX).yaml
-	rm -rf $(TMP_BASE)
+	#rm -rf $(TMP_BASE)
 
 .PHONY: $(BUILD_MC_TARGETS)
 $(BUILD_MC_TARGETS): $(KUSTOMIZE) $(HELM) $(YQ)


### PR DESCRIPTION
When we render locally or on CI we append vaultless patches to `patchesStrategicMerge` directly into Flux v2 app GS ksutomization. We have to append there because of upstream bug in kustomize that it cannot handle patch files with multiple documents and Flux still uses such a version.

For provider specific kustomizations it worked fine, because the vaultless patch was applied later. But if they are in the same file, it seems `patchesStrategicMerge` is applied before `patches` which renders an incorrect result.

We should keep these - and ones modifying the  same resources - in `patchesStrategicMerge` until Flux bumps to a `kustomize` version that has the bug fix.
