### PR TITLE
add cert-manager to snail/sample-customer

### DIFF
--- a/bases/provider/eks/helmrelease/cert-manager/README.md
+++ b/bases/provider/eks/helmrelease/cert-manager/README.md
@@ -1,0 +1,3 @@
+# Metrics server
+
+Deploys Giant Swarm's Cert-Manager.

--- a/bases/provider/eks/helmrelease/cert-manager/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/cert-manager/helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: sample-customer-cert-manager
+  namespace: org-sample
+spec:
+  releaseName: cert-manager
+  targetNamespace: kube-system
+  storageNamespace: kube-system
+  kubeConfig:
+    secretRef:
+      name: sample-customer-kubeconfig
+  chart:
+    spec:
+      chart: cert-manager-app
+      version: 3.5.3
+      sourceRef:
+        kind: HelmRepository
+        name: giantswarm-catalog
+        namespace: default
+  interval: 50m
+  install:
+    remediation:
+      retries: 3

--- a/bases/provider/eks/helmrelease/cert-manager/kustomization.yaml
+++ b/bases/provider/eks/helmrelease/cert-manager/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/bases/provider/eks/helmrelease/kustomization.yaml
+++ b/bases/provider/eks/helmrelease/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- cert-manager
 - example-helmrelease-app
 - metrics-server
 - fluent-logshipping-app


### PR DESCRIPTION
This PR adds `cert-manager` to `snail/sample-customer` WC.
