### PR TITLE
Upgrade kustomize to fix support for multiple patches in one file

### DIFF
--- a/bases/tools/Makefile.custom.mk
+++ b/bases/tools/Makefile.custom.mk
@@ -1,7 +1,7 @@
 # Check https://github.com/fluxcd/flux2/blob/main/.github/runners/prereq.sh if
 # you're updating kustomize versions.
 KUSTOMIZE := ./bin/kustomize
-KUSTOMIZE_VERSION ?= v5.0.3
+KUSTOMIZE_VERSION ?= v5.2.1
 
 HELM := ./bin/helm
 


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/kustomize/pull/5194 which was released in https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.2.1

When creating a new MC with `mc-bootstrap`, there are several patches in `custom-branches.yaml`, and the current version of kustomize doesn't support that:

```
$ make build-gandreasmc3
curl -sL https://raw.githubusercontent.com/giantswarm/management-cluster-bases/main/bases/tools/Makefile.custom.mk | /Applications/Xcode.app/Contents/Developer/usr/bin/make -f - build-gandreasmc3
====> bin/kustomize
mkdir -p bin/
curl -sfL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.0.3/kustomize_v5.0.3_darwin_arm64.tar.gz" | tar zxv -C bin/
x kustomize
chmod +x bin/kustomize
====> bin/helm
curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | HELM_INSTALL_DIR=bin/ USE_SUDO=false bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11664  100 11664    0     0   228k      0 --:--:-- --:--:-- --:--:--  242k
Downloading https://get.helm.sh/helm-v3.13.1-darwin-arm64.tar.gz
Verifying checksum... Done.
Preparing to install helm into bin/
helm installed into bin//helm
====> bin/yq
mkdir -p bin/
curl -sfL https://github.com/mikefarah/yq/releases/download/v4.31.2/yq_darwin_arm64 > bin/yq
chmod +x bin/yq
====> build-gandreasmc3
mkdir -p output
./bin/kustomize build --enable-alpha-plugins --load-restrictor LoadRestrictionsNone --enable-helm --helm-command="./bin/helm" management-clusters/gandreasmc3 > output/gandreasmc3.prep.yaml
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
Error: trouble configuring builtin PatchTransformer with config: `
path: custom-branches.yaml
`: unable to parse SM or JSON patch from [apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: GitRepository
metadata:
  name: collection
  namespace: flux-giantswarm
spec:
  ref:
    branch: gandreasmc3_auto_branch
---
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: GitRepository
metadata:
  name: management-clusters-fleet
  namespace: flux-giantswarm
spec:
  ref:
    branch: gandreasmc3_auto_branch
---
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: GitRepository
metadata:
  name: giantswarm-config
  namespace: flux-giantswarm
spec:
  ref:
    branch: gandreasmc3_auto_config
]
make[1]: *** [build-gandreasmc3] Error 1
make: *** [build-gandreasmc3] Error 2
```

With the new version, it's fixed, as tested manually via

```
rm -f bin/* && make build-gandreasmc3 KUSTOMIZE_VERSION=v5.2.1
```

Part of https://github.com/giantswarm/management-cluster-bases/issues/70