### PR TITLE
Upgrade batch API version to v1 in the flux-app-v2

### DIFF
--- a/bases/flux-app-v2/giantswarm/resource-refresh-vault-token.yaml
+++ b/bases/flux-app-v2/giantswarm/resource-refresh-vault-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: refresh-vault-token


### PR DESCRIPTION
After 1.25 the batch/v1beta1 is gone and it needs to be replaced by batch/v1

If we need to lock the version for certain cluster, the we might want to snapshot the state of the main branch before this PR is merged, and switch old clusters to that branch.