### PR TITLE
Make Flux ready for Kubernetes 1.25

### DIFF
--- a/bases/crds/flux-app-v2/crds.yaml
+++ b/bases/crds/flux-app-v2/crds.yaml
@@ -607,7 +607,7 @@ spec:
                   description: Insecure allows connecting to a non-TLS HTTP Endpoint.
                   type: boolean
                 interval:
-                  description: Interval at which to check the Endpoint for updates.
+                  description: Interval at which the Bucket Endpoint is checked for updates. This interval is approximate and may be subject to jitter to ensure efficient use of resources.
                   pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 provider:
@@ -826,9 +826,18 @@ spec:
                     type: object
                   type: array
                 interval:
-                  description: Interval at which to check the GitRepository for updates.
+                  description: Interval at which the GitRepository URL is checked for updates. This interval is approximate and may be subject to jitter to ensure efficient use of resources.
                   pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
+                proxySecretRef:
+                  description: ProxySecretRef specifies the Secret containing the proxy configuration to use while communicating with the Git server.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
                 recurseSubmodules:
                   description: RecurseSubmodules enables the initialization of all submodules within the GitRepository as cloned from the URL, using their default settings.
                   type: boolean
@@ -876,9 +885,13 @@ spec:
                   description: Verification specifies the configuration to verify the Git commit signature(s).
                   properties:
                     mode:
-                      description: Mode specifies what Git object should be verified, currently ('head').
+                      default: HEAD
+                      description: "Mode specifies which Git object(s) should be verified. \n The variants \"head\" and \"HEAD\" both imply the same thing, i.e. verify the commit that the HEAD of the Git repository points to. The variant \"head\" solely exists to ensure backwards compatibility."
                       enum:
                         - head
+                        - HEAD
+                        - Tag
+                        - TagAndHEAD
                       type: string
                     secretRef:
                       description: SecretRef specifies the Secret containing the public keys of trusted Git authors.
@@ -890,7 +903,6 @@ spec:
                         - name
                       type: object
                   required:
-                    - mode
                     - secretRef
                   type: object
               required:
@@ -1056,6 +1068,9 @@ spec:
                 observedRecurseSubmodules:
                   description: ObservedRecurseSubmodules is the observed resource submodules configuration used to produce the current Artifact.
                   type: boolean
+                sourceVerificationMode:
+                  description: SourceVerificationMode is the last used verification mode indicating which Git object(s) have been verified.
+                  type: string
               type: object
           type: object
       served: true
@@ -1930,7 +1945,7 @@ spec:
                   description: Chart is the name or path the Helm chart is available at in the SourceRef.
                   type: string
                 interval:
-                  description: Interval is the interval at which to check the Source for updates.
+                  description: Interval at which the HelmChart SourceRef is checked for updates. This interval is approximate and may be subject to jitter to ensure efficient use of resources.
                   pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 reconcileStrategy:
@@ -2320,7 +2335,7 @@ spec:
                       type: string
                   type: object
                 interval:
-                  description: Interval at which to reconcile the Helm release.
+                  description: Interval at which to reconcile the Helm release. This interval is approximate and may be subject to jitter to ensure efficient use of resources.
                   pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 kubeConfig:
@@ -2993,8 +3008,17 @@ spec:
                   required:
                     - namespaceSelectors
                   type: object
+                certSecretRef:
+                  description: "CertSecretRef can be given the name of a Secret containing either or both of \n - a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`); - a PEM-encoded CA certificate (`ca.crt`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate. The Secret must be of type `Opaque` or `kubernetes.io/tls`. \n It takes precedence over the values specified in the Secret referred to by `.spec.secretRef`."
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
                 interval:
-                  description: Interval at which to check the URL for updates.
+                  description: Interval at which the HelmRepository URL is checked for updates. This interval is approximate and may be subject to jitter to ensure efficient use of resources.
                   pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 passCredentials:
@@ -3010,7 +3034,7 @@ spec:
                     - gcp
                   type: string
                 secretRef:
-                  description: SecretRef specifies the Secret containing authentication credentials for the HelmRepository. For HTTP/S basic auth the secret must contain 'username' and 'password' fields. For TLS the secret must contain a 'certFile' and 'keyFile', and/or 'caFile' fields.
+                  description: SecretRef specifies the Secret containing authentication credentials for the HelmRepository. For HTTP/S basic auth the secret must contain 'username' and 'password' fields. Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile' keys is deprecated. Please use `.spec.certSecretRef` instead.
                   properties:
                     name:
                       description: Name of the referent.
@@ -3664,7 +3688,7 @@ spec:
                     - namespaceSelectors
                   type: object
                 certSecretRef:
-                  description: "CertSecretRef can be given the name of a secret containing either or both of \n - a PEM-encoded client certificate (`certFile`) and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate."
+                  description: "CertSecretRef can be given the name of a Secret containing either or both of \n - a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`); - a PEM-encoded CA certificate (`ca.crt`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate. The Secret must be of type `Opaque` or `kubernetes.io/tls`. \n Note: Support for the `caFile`, `certFile` and `keyFile` keys has been deprecated."
                   properties:
                     name:
                       description: Name of the referent.
@@ -3909,8 +3933,14 @@ spec:
                         branch:
                           description: Branch specifies that commits should be pushed to the branch named. The branch is created using `.spec.checkout.branch` as the starting point, if it doesn't already exist.
                           type: string
-                      required:
-                        - branch
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'Options specifies the push options that are sent to the Git server when performing a push operation. For details, see: https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt'
+                          type: object
+                        refspec:
+                          description: 'Refspec specifies the Git Refspec to use for a push operation. If both Branch and Refspec are provided, then the commit is pushed to the branch and also using the specified refspec. For more details about Git Refspecs, see: https://git-scm.com/book/en/v2/Git-Internals-The-Refspec'
+                          type: string
                       type: object
                   required:
                     - commit
@@ -4186,7 +4216,7 @@ spec:
                     type: object
                   type: array
                 interval:
-                  description: The interval at which to reconcile the Kustomization.
+                  description: The interval at which to reconcile the Kustomization. This interval is approximate and may be subject to jitter to ensure efficient use of resources.
                   pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 kubeConfig:
@@ -5331,7 +5361,7 @@ spec:
               description: OCIRepositorySpec defines the desired state of OCIRepository
               properties:
                 certSecretRef:
-                  description: "CertSecretRef can be given the name of a secret containing either or both of \n - a PEM-encoded client certificate (`certFile`) and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate."
+                  description: "CertSecretRef can be given the name of a Secret containing either or both of \n - a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`); - a PEM-encoded CA certificate (`ca.crt`) \n and whichever are supplied, will be used for connecting to the registry. The client cert and key are useful if you are authenticating with a certificate; the CA cert is useful if you are using a self-signed server certificate. The Secret must be of type `Opaque` or `kubernetes.io/tls`. \n Note: Support for the `caFile`, `certFile` and `keyFile` keys have been deprecated."
                   properties:
                     name:
                       description: Name of the referent.
@@ -5346,7 +5376,7 @@ spec:
                   description: Insecure allows connecting to a non-TLS HTTP container registry.
                   type: boolean
                 interval:
-                  description: The interval at which to check for image updates.
+                  description: Interval at which the OCIRepository URL is checked for updates. This interval is approximate and may be subject to jitter to ensure efficient use of resources.
                   pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
                 layerSelector:
@@ -5754,7 +5784,7 @@ spec:
                   maxLength: 2048
                   type: string
                 certSecretRef:
-                  description: CertSecretRef specifies the Secret containing a PEM-encoded CA certificate (`caFile`).
+                  description: "CertSecretRef specifies the Secret containing a PEM-encoded CA certificate (in the `ca.crt` key). \n Note: Support for the `caFile` key has been deprecated."
                   properties:
                     name:
                       description: Name of the referent.
@@ -5818,6 +5848,7 @@ spec:
                     - grafana
                     - githubdispatch
                     - pagerduty
+                    - datadog
                   type: string
                 username:
                   description: Username specifies the name under which events are posted.
@@ -5895,9 +5926,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
-    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: flux-system
     app.kubernetes.io/part-of: flux
+    app.kubernetes.io/component: notification-controller
   name: receivers.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
@@ -6427,3 +6458,4 @@ spec:
       storage: false
       subresources:
         status: {}
+

--- a/bases/flux-app-v2/customer/kustomization.yaml
+++ b/bases/flux-app-v2/customer/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
     namespace: flux-system
     repo: https://giantswarm.github.io/giantswarm-catalog/
     releaseName: customer-flux
-    version: v1.0.0
+    version: v1.2.0
     valuesInline:
       images:
         registry: docker.io

--- a/bases/flux-app-v2/giantswarm/kustomization.yaml
+++ b/bases/flux-app-v2/giantswarm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
     namespace: flux-giantswarm
     repo: https://giantswarm.github.io/giantswarm-catalog/
     releaseName: flux-giantswarm
-    version: v1.0.0
+    version: v1.2.0
     valuesInline:
       images:
         registry: docker.io
@@ -45,20 +45,6 @@ patches:
     - op: replace
       path: /rules/10/resourceNames/0
       value: flux-app-pvc-psp-giantswarm
-- target:
-    kind: PodSecurityPolicy
-    name: flux-app-pvc-psp
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: flux-app-pvc-psp-giantswarm
-- target:
-    kind: ClusterRoleBinding
-    name: cluster-reconciler
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: cluster-reconciler-giantswarm
 - target:
     kind: ClusterRoleBinding
     name: crd-controller
@@ -159,7 +145,6 @@ patches:
         - "--storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc"
 # Keeping this because of vaultless helper + upstream bug in kustomize to apply patch files with multiple documents
 patchesStrategicMerge:
-- patch-pvc-psp.yaml
 - patch-kustomize-controller.yaml
 resources:
 - resource-namespace.yaml

--- a/bases/flux-app-v2/giantswarm/resource-refresh-vault-token.yaml
+++ b/bases/flux-app-v2/giantswarm/resource-refresh-vault-token.yaml
@@ -33,7 +33,21 @@ spec:
                 - -lapp=kustomize-controller
               image: docker.io/giantswarm/docker-kubectl:1.18.8
               name: restart-kustomize-controller
+              securityContext:
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
           serviceAccountName: refresh-vault-token
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 2000
+            seccompProfile:
+              type: RuntimeDefault
           restartPolicy: OnFailure
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Flux should be compatible with k8s 1.25. The versions referenced in kustomizations is updated to the latest one. 

Since the chart upgrade also means upgrading the chart, CRDs are taken from the actual flux release. 

Security policies are also updated to make the installation PSS compliant 