### PR TITLE
Add backstage label to backstage helmrelease

### DIFF
--- a/extras/backstage/helmrelease-backstage.yaml
+++ b/extras/backstage/helmrelease-backstage.yaml
@@ -22,21 +22,21 @@ spec:
   interval: 1m
   postRenderers:
     - kustomize:
-      patchesStrategicMerge:
-        - apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            labels:
-              backstage.io/kubernetes-id: backstage
-            name: backstage
-          spec:
-            selector:
-              matchLabels:
+        patches:
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              labels:
                 backstage.io/kubernetes-id: backstage
-            template:
-              metadata:
-                labels:
+              name: backstage
+            spec:
+              selector:
+                matchLabels:
                   backstage.io/kubernetes-id: backstage
+              template:
+                metadata:
+                  labels:
+                    backstage.io/kubernetes-id: backstage
   targetNamespace: backstage
   timeout: 10m
   upgrade:


### PR DESCRIPTION
## Some hints on changes to this repository

`backstage.io/kubernetes-id` label was added to the `backstage` Helm Release. This label is needed by backstage Kubernetes plugin to fetch resources associated with a catalog component (backstage in this case).