### PR TITLE
Extend shared configs makefile

### DIFF
--- a/bases/tools/Makefile.custom.configs.mk
+++ b/bases/tools/Makefile.custom.configs.mk
@@ -1,13 +1,19 @@
+SHARED_CONFIGS_BRANCH ?= main
+
 TMPDIR := $(shell mktemp -d)
 
 assemble-config:
-	@git clone --quiet https://github.com/giantswarm/shared-configs $$TMPDIR
+	@git clone --quiet --depth 1 --branch "${SHARED_CONFIGS_BRANCH}" https://github.com/giantswarm/shared-configs $$TMPDIR
+	@rm -rf ./default
 	@mv $$TMPDIR/default ./
+	@rm -rf ./include
 	@mv $$TMPDIR/include ./
 	@rm -rf $$TMPDIR
 
 assemble-config-ssh:
-	@git clone --quiet git@github.com:giantswarm/shared-configs.git $$TMPDIR
+	@git clone --quiet --depth 1 --branch "${SHARED_CONFIGS_BRANCH}" git@github.com:giantswarm/shared-configs.git $$TMPDIR
+	@rm -rf ./default
 	@mv $$TMPDIR/default ./
+	@rm -rf ./include
 	@mv $$TMPDIR/include ./
 	@rm -rf $$TMPDIR


### PR DESCRIPTION
Related to: https://github.com/giantswarm/giantswarm/issues/29046

Added the `rm -rf` to clean up the existing dirs to re-assemble for the latest changes in the `shared-configs` repo, otherwise `mv` fails the the folder is not empty.

Added branch to assemble with to make it a little nicer.