### PR TITLE
Add missing team label to podmonitors

### DIFF
--- a/extras/external-secrets/podmonitor-external-secrets.yaml
+++ b/extras/external-secrets/podmonitor-external-secrets.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
   name: external-secrets
   namespace: external-secrets
 spec:
@@ -16,6 +18,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
   name: external-secrets-webhook
   namespace: external-secrets
 spec:
@@ -31,6 +35,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
+  labels:
+    application.giantswarm.io/team: honeybadger
   name: external-secrets-cert-controller
   namespace: external-secrets
 spec:


### PR DESCRIPTION
## Some hints on changes to this repository

### Public information only

This PR adds a missing team label to ensure the components are monitored by the proper prometheus

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
