### PR TITLE
Single Flux Instance

### DIFF
--- a/bases/flux-app-v2/customer/kustomization.yaml
+++ b/bases/flux-app-v2/customer/kustomization.yaml
@@ -36,6 +36,9 @@ patches:
     - op: add
       path: /metadata/namespace
       value: flux-system
+    - op: replace
+      path: /roleRef/name
+      value: crd-controller-giantswarm
 - target:
     kind: ClusterRoleBinding
     name: cluster-reconciler

--- a/bases/flux-app-v2/customer/kustomization.yaml
+++ b/bases/flux-app-v2/customer/kustomization.yaml
@@ -127,6 +127,5 @@ patches:
         - --storage-path=/data
         - "--storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc"
 resources:
-  - resource-kyverno-policies.yaml
   - resource-namespace.yaml
   - resource-rbac.yaml

--- a/bases/flux-app-v2/customer/kustomization.yaml
+++ b/bases/flux-app-v2/customer/kustomization.yaml
@@ -55,7 +55,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces
+        - --watch-all-namespaces=false
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -69,7 +69,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces
+        - --watch-all-namespaces=false
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -82,7 +82,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces
+        - --watch-all-namespaces=false
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -95,7 +95,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces
+        - --watch-all-namespaces=false
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -107,7 +107,7 @@ patches:
     - op: replace
       path: /spec/template/spec/containers/0/args
       value:
-        - --watch-all-namespaces
+        - --watch-all-namespaces=false
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -120,7 +120,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces
+        - --watch-all-namespaces=false
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election

--- a/bases/flux-app-v2/customer/resource-rbac.yaml
+++ b/bases/flux-app-v2/customer/resource-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: crd-controller
+  name: crd-controller-giantswarm
 subjects:
 - kind: ServiceAccount
   name: helm-controller

--- a/bases/flux-app-v2/customer/resource-rbac.yaml
+++ b/bases/flux-app-v2/customer/resource-rbac.yaml
@@ -1,20 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: flux-crd-controller
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: crd-controller
-subjects:
-- kind: ServiceAccount
-  name: automation
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: flux-crd-controller-sa
   namespace: default
 roleRef:
@@ -216,4 +202,3 @@ subjects:
   kind: ServiceAccount
   name: "automation"
   namespace: "default"
-

--- a/bases/flux-app-v2/giantswarm/kustomization.yaml
+++ b/bases/flux-app-v2/giantswarm/kustomization.yaml
@@ -76,7 +76,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces=false
+        - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -90,7 +90,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces=false
+        - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -103,7 +103,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces=false
+        - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -116,7 +116,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces=false
+        - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -128,7 +128,7 @@ patches:
     - op: replace
       path: /spec/template/spec/containers/0/args
       value:
-        - --watch-all-namespaces=false
+        - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -141,7 +141,7 @@ patches:
       path: /spec/template/spec/containers/0/args
       value:
         - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc
-        - --watch-all-namespaces=false
+        - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
@@ -152,6 +152,7 @@ patchesStrategicMerge:
 - patch-pvc-psp.yaml
 - patch-kustomize-controller.yaml
 resources:
+- resource-kyverno-policies.yaml
 - resource-namespace.yaml
 - resource-rbac.yaml
 - resource-refresh-vault-token.yaml

--- a/bases/flux-app-v2/giantswarm/resource-kyverno-policies.yaml
+++ b/bases/flux-app-v2/giantswarm/resource-kyverno-policies.yaml
@@ -9,7 +9,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"
@@ -31,7 +30,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"
@@ -52,7 +50,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"
@@ -77,7 +74,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"
@@ -101,7 +97,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"
@@ -122,7 +117,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"
@@ -140,7 +134,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"
@@ -158,7 +151,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"
@@ -176,7 +168,6 @@ spec:
       exclude:
         resources:
           namespaces:
-            - "flux-system"
             - "flux-giantswarm"
             - "giantswarm"
             - "monitoring"

--- a/bases/flux-app-v2/giantswarm/resource-rbac.yaml
+++ b/bases/flux-app-v2/giantswarm/resource-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: flux-crd-controller-giantswarm
+  name: flux-crd-controller
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bases/flux-app-v2/giantswarm/resource-rbac.yaml
+++ b/bases/flux-app-v2/giantswarm/resource-rbac.yaml
@@ -16,3 +16,32 @@ kind: ServiceAccount
 metadata:
   name: automation
   namespace: flux-giantswarm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: read-pods-and-logs
+  namespace: flux-giantswarm
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-flux-logs-automation
+  namespace: flux-giantswarm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: read-pods-and-logs
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: "automation"
+  namespace: "default"

--- a/bases/flux-app-v2/giantswarm/resource-rbac.yaml
+++ b/bases/flux-app-v2/giantswarm/resource-rbac.yaml
@@ -1,4 +1,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-crd-controller-giantswarm
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-controller-giantswarm
+subjects:
+- kind: ServiceAccount
+  name: automation
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flux-giantswarm-automation

--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -1,6 +1,17 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
+  name: customer-flux-provider
+  namespace: flux-giantswarm
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  timeout: 1h
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
   name: collection
   namespace: flux-giantswarm
 spec:

--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   interval: 1h
   ref:
-    branch: single-flux
+    branch: main
   timeout: 5m
   url: https://github.com/giantswarm/management-cluster-bases
 ---

--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   interval: 1h
   ref:
-    branch: main
+    branch: single-flux
   timeout: 5m
   url: https://github.com/giantswarm/management-cluster-bases
 ---

--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -8,6 +8,7 @@ spec:
   ref:
     branch: main
   timeout: 5m
+  url: ssh://git@ssh.github.com:${github_port:=443}/giantswarm/management-cluster-bases.git
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository

--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -4,10 +4,10 @@ metadata:
   name: customer-flux-provider
   namespace: flux-giantswarm
 spec:
-  interval: 30s
+  interval: 1h
   ref:
     branch: main
-  timeout: 1h
+  timeout: 5m
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository

--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -8,7 +8,7 @@ spec:
   ref:
     branch: main
   timeout: 5m
-  url: ssh://git@ssh.github.com:${github_port:=443}/giantswarm/management-cluster-bases.git
+  url: https://github.com/giantswarm/management-cluster-bases
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository

--- a/bases/flux-giantswarm-resources/resource-kustomizations.yaml
+++ b/bases/flux-giantswarm-resources/resource-kustomizations.yaml
@@ -6,11 +6,7 @@ metadata:
   namespace: flux-giantswarm
 spec:
   interval: 1h
-  # DO NOT use slashes in the comment to indicate the path, just "->".
   path: "bases/flux-app-v2/customer"
-  # Think about changing prune settings twice. Or three times. In fact, don't
-  # change it at all. You are risking deleting customer Workload Clusters and
-  # more.
   prune: false
   retryInterval: 30s
   timeout: 15m

--- a/bases/flux-giantswarm-resources/resource-kustomizations.yaml
+++ b/bases/flux-giantswarm-resources/resource-kustomizations.yaml
@@ -2,6 +2,27 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: customer-flux-provider
+  namespace: flux-giantswarm
+spec:
+  interval: 1h
+  # DO NOT use slashes in the comment to indicate the path, just "->".
+  path: "bases/flux-app-v2/customer"
+  # Think about changing prune settings twice. Or three times. In fact, don't
+  # change it at all. You are risking deleting customer Workload Clusters and
+  # more.
+  prune: false
+  retryInterval: 30s
+  timeout: 15m
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: customer-flux-provider
+    namespace: flux-giantswarm
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: crds
   namespace: flux-giantswarm
 spec:

--- a/bases/provider/aws-china/flux-v2/kustomization.yaml
+++ b/bases/provider/aws-china/flux-v2/kustomization.yaml
@@ -31,7 +31,6 @@ images:
   - name: giantswarm/fluxcd-kustomize-controller
     newName: giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/fluxcd-kustomize-controller
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/aws/flux-v2/kustomization.yaml
+++ b/bases/provider/aws/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/azure/flux-v2/kustomization.yaml
+++ b/bases/provider/azure/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/capa/flux-v2/kustomization.yaml
+++ b/bases/provider/capa/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/capz/flux-v2/kustomization.yaml
+++ b/bases/provider/capz/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/cloud-director/flux-v2/kustomization.yaml
+++ b/bases/provider/cloud-director/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/gcp/flux-v2/kustomization.yaml
+++ b/bases/provider/gcp/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/kvm/flux-v2/kustomization.yaml
+++ b/bases/provider/kvm/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/openstack/flux-v2/kustomization.yaml
+++ b/bases/provider/openstack/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/provider/vsphere/flux-v2/kustomization.yaml
+++ b/bases/provider/vsphere/flux-v2/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 patches:
   - path: patch-collection-gitrepository.yaml
 resources:
-  - ../../../flux-app-v2/customer
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
   - configmap-provider-data.yaml

--- a/bases/tools/Makefile.custom.mk
+++ b/bases/tools/Makefile.custom.mk
@@ -97,7 +97,7 @@ ifeq ($(ENFORCE_PSS),1)
 	$(YQ) e -i '(.helmCharts[] | select(.name == "flux-app") | .valuesInline.global.podSecurityStandards.enforced) = true' $(TMP_BASE)/kustomization.yaml
 endif
 ifdef BOOTSTRAP_CLUSTER
-ifneq ($(filter build-flux-app-customer,$(MAKECMDGOALS)),)
+ifneq ($(filter build-flux-app-giantswarm,$(MAKECMDGOALS)),)
 	$(YQ) e -i '(.helmCharts[] | select(.name == "flux-app") | .valuesInline.cilium.enforce) = false' $(TMP_BASE)/kustomization.yaml
 	$(YQ) e -i '(.helmCharts[] | select(.name == "flux-app") | .valuesInline.podMonitors.enabled) = false' $(TMP_BASE)/kustomization.yaml
 	$(YQ) e -i '(.helmCharts[] | select(.name == "flux-app") | .valuesInline.policyException.enforce) = false' $(TMP_BASE)/kustomization.yaml

--- a/extras/flux/patch-remove-psp.yaml
+++ b/extras/flux/patch-remove-psp.yaml
@@ -5,9 +5,17 @@ metadata:
   name: flux-app-pvc-psp-giantswarm
   namespace: flux-giantswarm
 ---
-#$patch: delete
-#apiVersion: policy/v1beta1
-#kind: PodSecurityPolicy
-#metadata:
-#  name: flux-app-pvc-psp
-#  namespace: flux-system
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: customer-flux-provider
+  namespace: flux-giantswarm
+spec:
+  patches:
+    - patch: |-
+        $patch: delete
+        apiVersion: policy/v1beta1
+        kind: PodSecurityPolicy
+        metadata:
+          name: flux-app-pvc-psp
+          namespace: flux-system

--- a/extras/flux/patch-remove-psp.yaml
+++ b/extras/flux/patch-remove-psp.yaml
@@ -5,9 +5,9 @@ metadata:
   name: flux-app-pvc-psp-giantswarm
   namespace: flux-giantswarm
 ---
-$patch: delete
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: flux-app-pvc-psp
-  namespace: flux-system
+#$patch: delete
+#apiVersion: policy/v1beta1
+#kind: PodSecurityPolicy
+#metadata:
+#  name: flux-app-pvc-psp
+#  namespace: flux-system

--- a/extras/flux/patch-remove-psp.yaml
+++ b/extras/flux/patch-remove-psp.yaml
@@ -5,6 +5,7 @@ metadata:
   name: flux-app-pvc-psp-giantswarm
   namespace: flux-giantswarm
 ---
+$patch: merge
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:


### PR DESCRIPTION
## Description ##

Context: https://github.com/giantswarm/giantswarm/issues/29194#issuecomment-1991968574

The essence of this PR is remove Customer Flux base entirely, but in two stages. The first stage is to transfer the ownership over it to a separate Kustomization CR, and hence removing them from the main stream of resources delivered by the `flux` Kustomization. This is to stay true to the rule of not enabling pruning on the main `flux` Kustomization CR and to introduce an extra means of safety - an isolated Kustomization CR and its inventory allows us to inspect resources before removing them, so have a chance to make sure nothing more than necessary is being removed. This way we also have a chance to migrate clusters one by one, which is more controllable manner than a global change. 

Postcondition for this stage is: Flux resources are managed by the Giantswarm Flux and the Customer Flux, while still running, is limited to the `flux-system` namespace only.

In the second stage we enable pruning on the new Kustomization CR and then remove it from the MCB. The new Kustomization CR is itself managed by Flux, the `flux` Kustomization CR to be precise, so when we remove it it won't get deleted from clusters. This is the one-by-one migration mechanism mentioned above. After removing it from the MCB it won't be part of the desired state, hence we can go cluster by cluster and remove it manually from it, by first inspecting the inventory and making sure all is good. Thanks to the pruning being enabled the Customer Flux resources will follow the deletion.