### PR TITLE
Move `appcatalog` CRD to vintage bases

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -1,6 +1,5 @@
 resources:
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_appcatalogentries.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_appcatalogs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_apps.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_catalogs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_charts.yaml

--- a/bases/crds/vintage/aws/v5.2.0/kustomization.yaml
+++ b/bases/crds/vintage/aws/v5.2.0/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - ../../common
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/core.giantswarm.io_awsclusterconfigs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awsclusters.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awscontrolplanes.yaml

--- a/bases/crds/vintage/aws/v6.6.0/kustomization.yaml
+++ b/bases/crds/vintage/aws/v6.6.0/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - ../../common
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/core.giantswarm.io_awsclusterconfigs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awsclusters.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awscontrolplanes.yaml

--- a/bases/crds/vintage/azure/v6.6.0/kustomization.yaml
+++ b/bases/crds/vintage/azure/v6.6.0/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - ../../common
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-azure/templates/core.giantswarm.io_azureclusterconfigs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-azure/templates/exp.cluster.x-k8s.io_machinepools.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-azure/templates/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml

--- a/bases/crds/vintage/common/kustomization.yaml
+++ b/bases/crds/vintage/common/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_appcatalogs.yaml

--- a/bases/crds/vintage/kvm/v6.6.0/kustomization.yaml
+++ b/bases/crds/vintage/kvm/v6.6.0/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - ../../common
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-kvm/templates/core.giantswarm.io_flannelconfigs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-kvm/templates/core.giantswarm.io_kvmclusterconfigs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-kvm/templates/provider.giantswarm.io_kvmconfigs.yaml


### PR DESCRIPTION
AppCatalogs were removed from CAPx clusters via https://github.com/giantswarm/management-cluster-bases/pull/112. This moves the CRD for it to new `vintage/common` base that was added to existing vintage bases.

After merge, no change needed other than the CRD manually cleaned from CAPx clusters (cos prune disabled).