### PR TITLE
Add vsphere-addons collection

### DIFF
--- a/extras/vsphere-addons/gitrepository-vsphere-addons-collection.yaml
+++ b/extras/vsphere-addons/gitrepository-vsphere-addons-collection.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: vsphere-addons-collection
+  namespace: flux-giantswarm
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  secretRef:
+    name: github-giantswarm-https-credentials
+  url: https://github.com/giantswarm/vsphere-addons-app-collection

--- a/extras/vsphere-addons/kustomization-vsphere-addons-collection.yaml
+++ b/extras/vsphere-addons/kustomization-vsphere-addons-collection.yaml
@@ -9,7 +9,7 @@ spec:
   force: false
   interval: 5m
   path: ./flux-manifests
-  prune: false
+  prune: true
   sourceRef:
     kind: GitRepository
     name: vsphere-addons-collection

--- a/extras/vsphere-addons/kustomization-vsphere-addons-collection.yaml
+++ b/extras/vsphere-addons/kustomization-vsphere-addons-collection.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vsphere-addons-collection
+  namespace: flux-giantswarm
+spec:
+  dependsOn:
+  - name: catalogs
+  force: false
+  interval: 5m
+  path: ./flux-manifests
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: vsphere-addons-collection
+    namespace: flux-giantswarm
+  retryInterval: 1m
+  targetNamespace: giantswarm
+  timeout: 3m

--- a/extras/vsphere-addons/kustomization.yaml
+++ b/extras/vsphere-addons/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- gitrepository-vsphere-addons-collection.yaml
+- kustomization-vsphere-addons-collection.yaml


### PR DESCRIPTION
We will add some vsphere specific apps on top of CAPZ collection to support multi-provider use cases.

Here is an example of how we will consume this change: https://github.com/giantswarm/giantswarm-management-clusters/blob/glippy_auto_branch/management-clusters/glippy/kustomization.yaml#L61