### PR TITLE
Disable resource hungry zot extensions

### DIFF
--- a/extras/zot/values.yaml
+++ b/extras/zot/values.yaml
@@ -95,14 +95,8 @@ configFiles:
               }
             ]
           },
-          "scrub": {
-            "enable": true
-          },
           "search": {
-            "enable": true,
-            "cve": {
-                "updateInterval": "2h"
-            }
+            "enable": false
           },
           "metrics": {
             "enable": true,


### PR DESCRIPTION
After removing these extensions I was able to bring the memory consuption down to ~150Mb, before that it was about ~15Gb, so I guess we might want to disable them

Issue: https://github.com/giantswarm/giantswarm/issues/30596
Issue: https://github.com/giantswarm/roadmap/issues/3069
