### PR TITLE
Re-enable zot's scrub extension

### DIFF
--- a/extras/zot/values.yaml
+++ b/extras/zot/values.yaml
@@ -95,6 +95,9 @@ configFiles:
               }
             ]
           },
+          "scrub": {
+            "enable": true
+          },
           "search": {
             "enable": false
           },


### PR DESCRIPTION
It seems not to be a memory hungry extensions, so we're enabling it again

Issue: https://github.com/giantswarm/roadmap/issues/3069


