### PR TITLE
Add cm postbuild for flux extras

### DIFF
--- a/bases/flux-giantswarm-resources/pss-enforcement/flux-extras-pssenforced.yaml
+++ b/bases/flux-giantswarm-resources/pss-enforcement/flux-extras-pssenforced.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  pssEnforced: "true"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: flux-extras-pssenforced
+  namespace: flux-giantswarm

--- a/bases/flux-giantswarm-resources/pss-enforcement/kustomization.yaml
+++ b/bases/flux-giantswarm-resources/pss-enforcement/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- flux-extras-pssenforced.yaml

--- a/bases/flux-giantswarm-resources/resource-kustomizations.yaml
+++ b/bases/flux-giantswarm-resources/resource-kustomizations.yaml
@@ -56,6 +56,11 @@ spec:
     kind: GitRepository
     name: management-clusters-fleet
     namespace: flux-giantswarm
+  postBuild:
+    substituteFrom:
+    - kind: ConfigMap
+      name: flux-extras-pssenforced
+      optional: true
   timeout: 3m
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/extras/crossplane/helmrelease-crossplane.yaml
+++ b/extras/crossplane/helmrelease-crossplane.yaml
@@ -27,3 +27,6 @@ spec:
   values:
     metrics:
       enabled: true
+    global:
+      podSecurityStandards:
+        enforced: ${pssEnforced:=true}

--- a/extras/crossplane/helmrelease-event-exporter.yaml
+++ b/extras/crossplane/helmrelease-event-exporter.yaml
@@ -25,4 +25,4 @@ spec:
   values:
     global:
       podSecurityStandards:
-        enforced: true
+        enforced: ${pssEnforced:=false}


### PR DESCRIPTION
This uses a postbuild substitution to replace the value iof a cm exists

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
