### PR TITLE
Deploy updated Release CRD from the Releases SDK repo

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -10,6 +10,6 @@ resources:
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_sparks.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_storageconfigs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/monitoring.giantswarm.io_silences.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/release.giantswarm.io_releases.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/security.giantswarm.io_organizations.yaml
   - https://raw.githubusercontent.com/giantswarm/rbac-operator/v0.39.0/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
+  - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.3.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml


### PR DESCRIPTION
## Some hints on changes to this repository

Towards https://github.com/giantswarm/roadmap/issues/3466

This PR adds the updated Release CRD where we have more flexible Release CR name validation, so we support new name format (`<provider>-<major>.<minor>.<patch>-<suffix>`) for CAPI releases.

This change is non-breaking and is backward compatible with Release CRs that are currently deployed to both CAPA and vintage MCs.