### PR TITLE
Bump Zot to 1.0.0 and set resource limits (to Go GC based approach)

### DIFF
--- a/extras/zot-cache/helm-release.yaml
+++ b/extras/zot-cache/helm-release.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: giantswarm-catalog
         namespace: flux-giantswarm
-      version: 0.3.1
+      version: 1.0.0
   install:
     remediation:
       retries: 10

--- a/extras/zot-cache/values.yaml
+++ b/extras/zot-cache/values.yaml
@@ -23,6 +23,24 @@ pvc:
   policyException:
     enforce: true
 
+giantswarm:
+  verticalPodAutoscaler:
+    enabled: false
+
+resources:
+  requests:
+    cpu: 300m
+    memory: 1024Mi
+  limits:
+    cpu: 500m
+    memory: 1024Mi
+
+env:
+  - name: "GOGC"
+    value: "50"
+  - name: "GOMEMLIMIT"
+    value: "800MiB"
+
 global:
   podSecurityStandards:
     enforced: true
@@ -97,6 +115,9 @@ configFiles:
           },
           "scrub": {
             "enable": true
+          },
+          "ui": {
+            "enable": false
           },
           "search": {
             "enable": false


### PR DESCRIPTION
Bump `zot` to `v1.0.0` and set hard limit on memory usage with Go GC enabled.

See: https://github.com/giantswarm/giantswarm/issues/31020#issuecomment-2172989482