### PR TITLE
Enable zot registry credentials file by default

### DIFF
--- a/extras/zot-cache/README.md
+++ b/extras/zot-cache/README.md
@@ -80,6 +80,9 @@ secretFiles:
   htpasswd: |-
     admin:$2y$05$vmiurPmJvHylk78HHFWuruFFVePlit9rZWGA/FbZfTEmNRneGJtha
     prom:$2y$05$L86zqQDfH5y445dcMlwu6uHv.oXFgT6AiJCwpv3ehr7idc0rI3S2G
+  # See https://zotregistry.dev/latest/articles/mirroring/
+  credentials: |-
+    {}
 ```
 
 Also, to let prometheus scrape metrics, you need to add a BasicAuth to service monitor.

--- a/extras/zot-cache/values.yaml
+++ b/extras/zot-cache/values.yaml
@@ -101,6 +101,8 @@ configFiles:
         },
         "extensions": {
           "sync": {
+            "enable": true,
+            "credentialsFile": "/secret/credentials",
             "registries": [
               {
                 "urls": [


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3460

The cred file content must be generated for each MC using this extra base. At its current state it wont make zot fail if we dont have the file, it will just log an error.

Unfortunately because of the nature of the upstream chart you would have to overwrite the whole Zot config just to change 1 small thing.