### PR TITLE
Fix cluster config build in Makefile

### DIFF
--- a/bases/tools/Makefile.custom.mk
+++ b/bases/tools/Makefile.custom.mk
@@ -134,8 +134,7 @@ $(BUILD_MC_TARGETS): $(KUSTOMIZE) $(HELM) $(YQ)
 	$(if $(filter 1,$(ENFORCE_PSS)), \
 	    $(YQ) eval 'select(.kind != "PodSecurityPolicy" or (.kind == "PodSecurityPolicy" and .metadata.name != "flux-app-pvc-psp" and .metadata.name != "flux-app-pvc-psp-giantswarm"))' -i output/$(subst build-,,$@).yaml; \
 	    $(YQ) eval 'del(.rules[] | select(.resources[] == "podsecuritypolicies" and .resourceNames[] == "flux-app-pvc-psp"))' -i output/$(subst build-,,$@).yaml; \
-	    $(YQ) eval 'del(.rules[] | select(.resources[] == "podsecuritypolicies" and .resourceNames[] == "flux-app-pvc-psp-giantswarm"))' -i output/$(subst build-,,$@).yaml; \
-		  $(YQ) e -i 'select(.kind == "ConfigMap" and .metadata.name == "$(subst build-,,$@)-user-values").data.values += "\nglobal:\n  podSecurityStandards:\n    enforced: true\n"' output/$(subst build-,,$@).yaml)
+	    $(YQ) eval 'del(.rules[] | select(.resources[] == "podsecuritypolicies" and .resourceNames[] == "flux-app-pvc-psp-giantswarm"))' -i output/$(subst build-,,$@).yaml)
 	[ $(GNU_SED) -eq 0 ] && sed -i 's/$$$${/$${/g' output/$(subst build-,,$@).yaml || sed -i "" 's/$$$${/$${/g' output/$(subst build-,,$@).yaml
 	rm -f output/$(subst build-,,$@).prep.yaml output/$(subst build-,,$@).env output/$(subst build-,,$@).envsubst
 


### PR DESCRIPTION
This removes a `yq` command from the bases/tools/Makefile.custom.mk that was messing up with the cluster ConfigMap during bootstrap.

This was rendering the original cluster config useless since it shades every configuration property under `global`

See this PR for context: https://github.com/giantswarm/mc-bootstrap/pull/945

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
