### PR TITLE
Remove taylorbot token

### DIFF
--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -7,8 +7,6 @@ spec:
   interval: 30s
   ref:
     branch: master
-  secretRef:
-    name: github-giantswarm-https-credentials
   timeout: 5m
 ---
 apiVersion: source.toolkit.fluxcd.io/v1

--- a/extras/vsphere-addons/gitrepository-vsphere-addons-collection.yaml
+++ b/extras/vsphere-addons/gitrepository-vsphere-addons-collection.yaml
@@ -7,6 +7,4 @@ spec:
   interval: 30s
   ref:
     branch: main
-  secretRef:
-    name: github-giantswarm-https-credentials
   url: https://github.com/giantswarm/vsphere-addons-app-collection


### PR DESCRIPTION
The `taylorbot` token was used to give `flux` access to the private `collection` repositories, but they are all public now, so the secret is no longer required.