### PR TITLE
add vsphere aws addons collection

### DIFF
--- a/extras/vsphere-aws-addons/gitrepository-vsphere-addons-collection.yaml
+++ b/extras/vsphere-aws-addons/gitrepository-vsphere-addons-collection.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: vsphere-aws-addons-collection
+  namespace: flux-giantswarm
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  url: https://github.com/giantswarm/vsphere-aws-addons-app-collection

--- a/extras/vsphere-aws-addons/kustomization-vsphere-addons-collection.yaml
+++ b/extras/vsphere-aws-addons/kustomization-vsphere-addons-collection.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vsphere-aws-addons-collection
+  namespace: flux-giantswarm
+spec:
+  dependsOn:
+  - name: catalogs
+  force: false
+  interval: 5m
+  path: ./flux-manifests
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: vsphere-aws-addons-collection
+    namespace: flux-giantswarm
+  retryInterval: 1m
+  targetNamespace: giantswarm
+  timeout: 3m

--- a/extras/vsphere-aws-addons/kustomization.yaml
+++ b/extras/vsphere-aws-addons/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- gitrepository-vsphere-aws-addons-collection.yaml
+- kustomization-vsphere-aws-addons-collection.yaml


### PR DESCRIPTION
https://github.com/giantswarm/roadmap/issues/3624

We need a separate addons collection for capv on capa due to the fact that it uses a different dns operator.

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
