### PR TITLE
`organization` CRD from operator repo

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -10,6 +10,6 @@ resources:
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_sparks.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_storageconfigs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/monitoring.giantswarm.io_silences.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/security.giantswarm.io_organizations.yaml
+  - https://raw.githubusercontent.com/giantswarm/organization-operator/v2.0.1/config/crd/bases/security.giantswarm.io_organizations.yaml
   - https://raw.githubusercontent.com/giantswarm/rbac-operator/v0.39.0/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
   - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.3.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml


### PR DESCRIPTION
Towards: 
- [issue #3530](https://github.com/giantswarm/roadmap/issues/3530) 
- [Slack threads](https://gigantic.slack.com/archives/C02HLSDH3DZ/p1724141279076229)
### This PR
- Changes the `organization` CRD repo, from the `apiextensions` repo to the `organization-operator` one