### PR TITLE
CAPI: Include `releases` by default.

### DIFF
--- a/bases/provider/capa/flux-v2/kustomization.yaml
+++ b/bases/provider/capa/flux-v2/kustomization.yaml
@@ -5,4 +5,5 @@ patches:
 resources:
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
+  - ../releases
   - configmap-provider-data.yaml

--- a/bases/provider/capz/flux-v2/kustomization.yaml
+++ b/bases/provider/capz/flux-v2/kustomization.yaml
@@ -5,4 +5,5 @@ patches:
 resources:
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
+  - ../releases
   - configmap-provider-data.yaml

--- a/bases/provider/vsphere/flux-v2/kustomization.yaml
+++ b/bases/provider/vsphere/flux-v2/kustomization.yaml
@@ -5,4 +5,5 @@ patches:
 resources:
   - ../../../flux-app-v2/giantswarm
   - ../../../flux-giantswarm-resources
+  - ../releases
   - configmap-provider-data.yaml


### PR DESCRIPTION
With this, MCs of CAPI providers, which are currently supported by Releases, include their respective Flux managed Releases Kustomization by default.

This change is required or at least it makes the most sense, because right now we are already including the provider specific Kustomization here:

https://github.com/giantswarm/giantswarm-management-clusters/blob/main/management-clusters/gaggle/kustomization.yaml#L63

So with this change each MC would get its provider specific Releases Kustomization.

Without this change we would need to add an extra line to each MC's Kustomization just to install its provider specific Releases Kustomization.

I'm including the provider specific Releases Kustomization here, as we need to keep them reusable for multi-provider installations. For these I need to be able to still add a separate line for including more Releases Kustomizations in the MC's Kustomization.