### PR TITLE
Collection: Enable `prune`.

### DIFF
--- a/bases/flux-giantswarm-resources/resource-kustomizations.yaml
+++ b/bases/flux-giantswarm-resources/resource-kustomizations.yaml
@@ -123,7 +123,7 @@ spec:
       name: prometheus-operator-app
       namespace: giantswarm
   path: ./flux-manifests
-  prune: false
+  prune: true
   retryInterval: 1m
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
This PR sets `prune` to `true` as we need to remove the `releases-<provider>` app from collections.