### PR TITLE
Releases: Enable `prune`.

### DIFF
--- a/bases/releases/releases.yaml
+++ b/bases/releases/releases.yaml
@@ -8,5 +8,5 @@ spec:
     kind: GitRepository
     name: releases
     namespace: flux-giantswarm
-  prune: false
+  prune: true
   interval: 1m


### PR DESCRIPTION
This PR enables `prune` for the provider specific `releases` Kustomization so archived Release CRs are getting removed from MCs.