### PR TITLE
CRDs: Bump `releases.release.giantswarm.io` to v0.10.0.

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/monitoring.giantswarm.io_silences.yaml
   - https://raw.githubusercontent.com/giantswarm/organization-operator/v2.0.1/config/crd/bases/security.giantswarm.io_organizations.yaml
   - https://raw.githubusercontent.com/giantswarm/rbac-operator/v0.39.0/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
-  - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.3.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
+  - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.10.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3651.

Following is the diff of the `releases.release.giantswarm.io` CRD between v0.3.0 and v0.10.0.

```
git diff sdk/v0.3.0:sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml sdk/v0.10.0:sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
```
```diff
diff --git a/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml b/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
index 3b9f82f..91dd431 100644
--- a/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
+++ b/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
@@ -29,6 +29,10 @@ spec:
       jsonPath: .spec.date
       name: Age
       type: date
+    - description: State of this release
+      jsonPath: .spec.state
+      name: State
+      type: string
     - description: Release notes for this release
       jsonPath: .metadata.annotations['giantswarm\.io/release-notes']
       name: Release notes
```