### PR TITLE
Collect metrics from Crossplane providers

### DIFF
--- a/extras/crossplane/podmonitor-crossplane.yaml
+++ b/extras/crossplane/podmonitor-crossplane.yaml
@@ -10,7 +10,7 @@ spec:
     matchNames:
       - 'crossplane'
   selector:
-    matchLabels:
-      app.kubernetes.io/name: crossplane
+    # All pods in the namespace are covered (includes Crossplane provider pods)`
+    matchLabels: {}
   podMetricsEndpoints:
     - targetPort: metrics


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3853 – we want the high-level gauges `crossplane_managed_resource_*`. Scrape metrics from all pods in the `crossplane` namespace in order to cover the provider pods which emit those metrics.

This successfully works on a test MC.