### PR TITLE
Prepare for Kyverno v1.13 release

### DIFF
--- a/bases/flux-app-v2/giantswarm/kustomization.yaml
+++ b/bases/flux-app-v2/giantswarm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
     namespace: flux-giantswarm
     repo: https://giantswarm.github.io/giantswarm-catalog/
     releaseName: flux-giantswarm
-    version: 1.3.1
+    version: 1.4.3
     valuesInline:
       images:
         registry: gsoci.azurecr.io

--- a/bases/flux-app-v2/giantswarm/resource-kyverno-policies.yaml
+++ b/bases/flux-app-v2/giantswarm/resource-kyverno-policies.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: flux-multi-tenancy
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
     - name: serviceAccountNameMustBeSet
       exclude:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32007

The usage of `enforce` has been depreacted. We should use `Enforce` instead.
We need to also update `PolicyExceptions` to `v2beta1`, so we are updating `flux-app` too.