### PR TITLE
Disable github.io override in source-controller in China

### DIFF
--- a/bases/provider/aws-china/flux-v2/patch-source-controller.yaml
+++ b/bases/provider/aws-china/flux-v2/patch-source-controller.yaml
@@ -10,9 +10,6 @@ spec:
       - ip: "192.168.190.100"
         hostnames:
           - "github.com"
-      - ip: "192.168.190.101"
-        hostnames:
-        - "giantswarm.github.io"
       - ip: "192.168.190.102"
         hostnames:
         - "ssh.github.com"

--- a/bases/provider/aws-china/flux-v2/patch-source-controller.yaml
+++ b/bases/provider/aws-china/flux-v2/patch-source-controller.yaml
@@ -10,6 +10,10 @@ spec:
       - ip: "192.168.190.100"
         hostnames:
           - "github.com"
+      # Uncomment this to move traffic back to DirectConnect
+      # - ip: "192.168.190.101"
+      #   hostnames:
+      #   - "giantswarm.github.io"
       - ip: "192.168.190.102"
         hostnames:
         - "ssh.github.com"


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
