### PR TITLE
Add Silences GitOps

### DIFF
--- a/bases/flux-giantswarm-resources/resource-kustomizations.yaml
+++ b/bases/flux-giantswarm-resources/resource-kustomizations.yaml
@@ -131,3 +131,22 @@ spec:
     namespace: flux-giantswarm
   targetNamespace: giantswarm
   timeout: 3m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: silences
+  namespace: flux-giantswarm
+spec:
+  dependsOn:
+    - name: flux
+  interval: 5m
+  # DO NOT use slashes in the comment to indicate the path, just "->".
+  path: "./management-clusters/{replaced in management-clusters -> <MC_NAME> -> kustomization.yaml}/silences"
+  prune: false
+  retryInterval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: management-clusters-fleet
+    namespace: flux-giantswarm
+  timeout: 3m

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,0 +1,2 @@
+namePrefix: common-
+resources: []


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30437

This PR adds configuration elements in orde to deploy Silences CRs using GitOps.

### What's added

-  a `Kustomization` CR to fetch and deploy Silences CRs specific to management cluster which are pulled from `<customer name>-management-cluster` repositories
- a `bases/silences/kustomization.yaml` in order to be able to create Silences CR in this repository which are common to all management clusters.