### PR TITLE
Add silences validation in CI

### DIFF
--- a/.github/actions/silences-validate/action.yaml
+++ b/.github/actions/silences-validate/action.yaml
@@ -48,6 +48,7 @@ runs:
         for directory in ${{ inputs.directory_pattern }}; do
           echo "Validating silences CRs in $directory"
           kustomize build "$directory" --output "${directory}/resources.yaml"
+          test -s "${directory}/resources.yaml" || continue
           kubectl apply -f "${directory}/resources.yaml"
           kubectl delete -f "${directory}/resources.yaml"
         done

--- a/.github/actions/silences-validate/action.yaml
+++ b/.github/actions/silences-validate/action.yaml
@@ -1,0 +1,53 @@
+# Github action used to validate silences CR files added to this repository.
+# Using an action rather than a workflow to be able to pass different inputs depending where it is called from, since workflows do not support inputs for push events.
+name: "Silences validate"
+description: "Validate silences CR files"
+inputs:
+  directory_pattern:
+    description: "Bash pattern to match directories containing silence CR files"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    # Set PATH to include GitHub Action path
+    # This is needed to run the silences-validate.sh script
+    - name: Set GitHub Path
+      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+      shell: bash
+      env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+    # Install dependencies
+    # yq: is used by silences-validate.sh
+    # kustomize: is used to validate silences CRs
+    - name: Install dependencies
+      shell: bash
+      run: |
+        make bin/yq
+        make bin/kustomize
+    # Check for non-empty directory_pattern and valid directories
+    - name: Check directory pattern
+      shell: bash
+      run: |
+        test -n "${{ inputs.directory_pattern }}" && \
+          printf "%s\n" ${{ inputs.directory_pattern }} | xargs -I{} test -d {} && echo ok
+    # Run files validation for each directory
+    - name: Validate silences files
+      shell: bash
+      run: |
+        for directory in ${{ inputs.directory_pattern }}; do
+          echo "Validating silences files in $directory"
+          silences-validate.sh "$directory"
+        done
+    - name: Setup kind cluster
+      uses: helm/kind-action@v1
+    # Run CR validation for each directory
+    - name: Validate silences CRs
+      shell: bash
+      run: |
+        kubectl create -f https://raw.githubusercontent.com/giantswarm/silence-operator/master/config/crd/monitoring.giantswarm.io_silences.yaml
+        for directory in ${{ inputs.directory_pattern }}; do
+          echo "Validating silences CRs in $directory"
+          kustomize build "$directory" --output "${directory}/resources.yaml"
+          kubectl apply -f "${directory}/resources.yaml"
+          kubectl delete -f "${directory}/resources.yaml"
+        done

--- a/.github/actions/silences-validate/silences-validate.sh
+++ b/.github/actions/silences-validate/silences-validate.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+YQ="bin/yq"
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+error() {
+  echo -e "${RED}$*${NC}" >&2
+}
+
+# no_yml fail if file has .yml extension
+no_yml() {
+  # Reject .yml
+  if [[ "$1" =~ .*\.yml ]]; then
+    error "  [err] wrong extension, please use .yaml"
+    return 1
+  fi
+  echo "  [ok] no .yml"
+}
+
+# skip_non_yaml fail if file does not have .yaml extension
+skip_non_yaml() {
+  if [[ ! "$1" =~ .*\.yaml ]]; then
+    echo "  [ok] skipping non .yaml file"
+    return 1
+  fi
+}
+
+# valid_until_date fail if valid-until annotation is missing or invalid
+valid_until_date() {
+  valid_until_annotation="$($YQ e '.metadata.annotations.valid-until' "$1")" || return 1
+  if [[ -n "$valid_until_annotation" ]] && [[ "$valid_until_annotation" != "null" ]]; then
+    if ! valid_until="$(date --rfc-3339=date -d "${valid_until_annotation}" 2>&1)"; then
+      error "  [err] valid until : $valid_until"
+      return 1
+    fi
+    echo "  [ok] valid until correct $valid_until"
+  else
+    error "  [err] valid until required"
+    return 1
+  fi
+}
+
+# validate_kustomization_resources fail if resource is not found in kustomization.yaml
+validate_kustomization_resources() {
+  file_basename="$(basename "$1")"
+  if ! echo "${KUSTOMIZATION_RESOURCES}" | grep -qE "^${file_basename}$"; then
+    error "  [err] resource ${file_basename} not found in kustomization.yaml"
+    return 1
+  fi
+  echo "  [ok] resource ${file_basename} found in kustomization.yaml"
+}
+
+main() {
+  echo "> start"
+
+  # Get default branch and merge base to compare against
+  default_branch="$(git remote show origin | grep 'HEAD' | cut -d':' -f2 | tr -d '[[:space:]]')"
+  merge_base="$(git merge-base HEAD "origin/$default_branch")"
+  # Get the root of the git repository
+  git_root="$(git rev-parse --show-toplevel)"
+
+  silences_path="${git_root}/${1}"
+  # Assume kustomization.yaml is at root of silences path
+  kustomization_path="$silences_path/kustomization.yaml"
+
+  # List resources referenced in kustomization.yaml
+  KUSTOMIZATION_RESOURCES="$($YQ e '.resources[]' "$kustomization_path")"
+
+  # Detect files which changed between the current HEAD and the remote default branch in the silences path
+  mapfile -t changed_files < <(git --no-pager diff --name-only "$merge_base" HEAD -- "${silences_path}" ":(exclude)$kustomization_path")
+  echo "> found ${#changed_files[@]} changed files between $(git rev-parse --abbrev-ref HEAD) and $default_branch"
+
+  # Run file checks
+  local has_error=false
+  for file in "${changed_files[@]}"; do
+    file_path="${git_root}/${file}"
+    echo "> checking $file_path"
+
+    no_yml "$file_path"                      || has_error=true
+    skip_non_yaml "$file_path"               || continue
+    valid_until_date "$file_path"            || has_error=true
+    validate_kustomization_resources "$file" || has_error=true
+
+  done
+
+  if $has_error; then
+    error "> failed"
+    exit 1
+  fi
+
+  echo "> success"
+}
+
+ main "$@"

--- a/.github/actions/silences-validate/silences-validate.sh
+++ b/.github/actions/silences-validate/silences-validate.sh
@@ -11,22 +11,13 @@ error() {
   echo -e "${RED}$*${NC}" >&2
 }
 
-# no_yml fail if file has .yml extension
-no_yml() {
-  # Reject .yml
-  if [[ "$1" =~ .*\.yml ]]; then
+# yaml_extension fail if file does not have .yaml extension
+yaml_extension() {
+  if ! [[ "$1" =~ .*\.yaml ]]; then
     error "  [err] wrong extension, please use .yaml"
     return 1
   fi
-  echo "  [ok] no .yml"
-}
-
-# skip_non_yaml fail if file does not have .yaml extension
-skip_non_yaml() {
-  if [[ ! "$1" =~ .*\.yaml ]]; then
-    echo "  [ok] skipping non .yaml file"
-    return 1
-  fi
+  echo "  [ok] .yaml extension"
 }
 
 # valid_until_date fail if valid-until annotation is missing or invalid
@@ -80,8 +71,7 @@ main() {
     file_path="${git_root}/${file}"
     echo "> checking $file_path"
 
-    no_yml "$file_path"                      || has_error=true
-    skip_non_yaml "$file_path"               || continue
+    yaml_extension "$file_path"              || has_error=true
     valid_until_date "$file_path"            || has_error=true
     validate_kustomization_resources "$file" || has_error=true
 

--- a/.github/workflows/silences-validate.yaml
+++ b/.github/workflows/silences-validate.yaml
@@ -11,6 +11,6 @@ jobs:
         with:
           # Fetch all history so silences-validate.sh can find changed files.
           fetch-depth: 0
-      - uses: giantswarm/management-cluster-bases/.github/actions/silences-validate@silences-ci
+      - uses: giantswarm/management-cluster-bases/.github/actions/silences-validate@main
         with:
           directory_pattern: '*/silences'

--- a/.github/workflows/silences-validate.yaml
+++ b/.github/workflows/silences-validate.yaml
@@ -1,0 +1,16 @@
+name: Validate silences
+
+on: [push, pull_request]
+
+jobs:
+  silences_validate:
+    runs-on: ubuntu-latest
+    name: Validate silences
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch all history so silences-validate.sh can find changed files.
+          fetch-depth: 0
+      - uses: giantswarm/management-cluster-bases/.github/actions/silences-validate@silences-ci
+        with:
+          directory_pattern: '*/silences'

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -41,3 +41,8 @@ $(BUILD_CRD_TARGETS): $(KUSTOMIZE) ## Build CRDs
 	mkdir -p output
 
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone bases/crds/$(subst build-,,$(subst -crds,,$@)) -o output/$(subst build-,,$(subst -crds,,$@))-crds.yaml
+
+silences-validate: $(YQ) ## Validate silences
+	@echo "====> $@"
+
+	./.github/actions/silences-validate/silences-validate.sh $(directory)

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,0 +1,2 @@
+namePrefix: common-
+resources: []


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30437

This PR adds a GitHub action to validate silences files in CI. The PR does:

- Add a re-usable Github action
- Add Github workflow to run the action in this directory
- Change the `silences-validate.sh` script to work with this repository, it was mostly taken from https://github.com/giantswarm/silences/blob/main/scripts/validate-files.sh, with some modifications:
  - added check for kustomization resources
  - added silences directory path as argument
  - added color output for errors, to ease reading in CI logs
  - changed yq path to work with this repository
  - fixed returned value on error using pipefail
  - fixed undetected empty valid-until annotation


<details>
<summary>silences-validate.sh diff</summary>

```diff
--- ../silences/scripts/validate-files.sh	2025-02-04 15:17:59.832664729 +0100
+++ .github/actions/silences-validate/silences-validate.sh	2025-03-20 09:45:28.268539681 +0100
@@ -1,65 +1,94 @@
 #!/usr/bin/env bash

-set -eu
+set -euo pipefail

-SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+YQ="bin/yq"

+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+error() {
+  echo -e "${RED}$*${NC}" >&2
+}
+
+# no_yml fail if file has .yml extension
 no_yml() {
   # Reject .yml
   if [[ "$1" =~ .*\.yml ]]; then
-    echo "  [err] wrong extension, please use .yaml"
+    error "  [err] wrong extension, please use .yaml"
     return 1
   fi
   echo "  [ok] no .yml"
 }

+# skip_non_yaml fail if file does not have .yaml extension
 skip_non_yaml() {
-  # Skip non yaml files
   if [[ ! "$1" =~ .*\.yaml ]]; then
     echo "  [ok] skipping non .yaml file"
     return 1
   fi
 }

+# valid_until_date fail if valid-until annotation is missing or invalid
 valid_until_date() {
-  # Validate date from valid_until annotation
-  valid_until_annotation="$(yq e '.metadata.annotations.valid-until' "$1")"
-  if [[ "$valid_until_annotation" != "null" ]]; then
-    if ! valid_until="$(date "+%s" -d "${valid_until_annotation}" 2>&1)"; then
-      echo "  [err] valid until : $valid_until"
+  valid_until_annotation="$($YQ e '.metadata.annotations.valid-until' "$1")" || return 1
+  if [[ -n "$valid_until_annotation" ]] && [[ "$valid_until_annotation" != "null" ]]; then
+    if ! valid_until="$(date --rfc-3339=date -d "${valid_until_annotation}" 2>&1)"; then
+      error "  [err] valid until : $valid_until"
       return 1
     fi
     echo "  [ok] valid until correct $valid_until"
   else
-    echo "  [err] valid until required"
+    error "  [err] valid until required"
+    return 1
+  fi
+}
+
+# validate_kustomization_resources fail if resource is not found in kustomization.yaml
+validate_kustomization_resources() {
+  file_basename="$(basename "$1")"
+  if ! echo "${KUSTOMIZATION_RESOURCES}" | grep -qE "^${file_basename}$"; then
+    error "  [err] resource ${file_basename} not found in kustomization.yaml"
     return 1
   fi
+  echo "  [ok] resource ${file_basename} found in kustomization.yaml"
 }

 main() {
   echo "> start"
-  cd "${SCRIPT_DIR}/.."

+  # Get default branch and merge base to compare against
   default_branch="$(git remote show origin | grep 'HEAD' | cut -d':' -f2 | tr -d '[[:space:]]')"
   merge_base="$(git merge-base HEAD "origin/$default_branch")"
-  # Detect files which changed between the current HEAD and the remote default branch.
-  # Only keep first level files.
-  mapfile -t changed_files < <(git --no-pager diff --name-only HEAD "$merge_base" | grep "^[^/]*$")
+  # Get the root of the git repository
+  git_root="$(git rev-parse --show-toplevel)"
+
+  silences_path="${git_root}/${1}"
+  # Assume kustomization.yaml is at root of silences path
+  kustomization_path="$silences_path/kustomization.yaml"
+
+  # List resources referenced in kustomization.yaml
+  KUSTOMIZATION_RESOURCES="$($YQ e '.resources[]' "$kustomization_path")"
+
+  # Detect files which changed between the current HEAD and the remote default branch in the silences path
+  mapfile -t changed_files < <(git --no-pager diff --name-only "$merge_base" HEAD -- "${silences_path}" ":(exclude)$kustomization_path")
   echo "> found ${#changed_files[@]} changed files between $(git rev-parse --abbrev-ref HEAD) and $default_branch"

   # Run file checks
   local has_error=false
   for file in "${changed_files[@]}"; do
-    echo "> checking $file"
+    file_path="${git_root}/${file}"
+    echo "> checking $file_path"

-    no_yml "$file"           || has_error=true
-    skip_non_yaml "$file"    || continue
-    valid_until_date "$file" || has_error=true
+    no_yml "$file_path"                      || has_error=true
+    skip_non_yaml "$file_path"               || continue
+    valid_until_date "$file_path"            || has_error=true
+    validate_kustomization_resources "$file" || has_error=true

   done

   if $has_error; then
-    echo "> fail"
+    error "> failed"
     exit 1
   fi
```

</details>

### Test cases

- incorrect .yml extension: [run](https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/13901403612/job/38893850290)
- incorrect date: [run](https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/13901461506/job/38894036830)
- incorrect CR: [run](https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/13901493317/job/38894140592)
- incorrect duplicated name: [run](https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/13901711831/job/38894868178)
- incorrect dangling resource: [run](https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/13902343329/job/38896971563)
- correct same silence on 2 MC: [run](https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/13901608966/job/38894530351)
- colored output: [run](https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/13902478094/job/38897413243)