### PR TITLE
Upgrade Silences CRD

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
   - https://raw.githubusercontent.com/giantswarm/apiextensions-application/v0.6.2/config/crd/application.giantswarm.io_apps.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_catalogs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_charts.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/monitoring.giantswarm.io_silences.yaml
+  - https://raw.githubusercontent.com/giantswarm/silence-operator/refs/tags/v0.13.0/config/crd/monitoring.giantswarm.io_silences.yaml
   - https://raw.githubusercontent.com/giantswarm/organization-operator/v2.0.1/config/crd/bases/security.giantswarm.io_organizations.yaml
   - https://raw.githubusercontent.com/giantswarm/rbac-operator/v0.39.0/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
   - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.10.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30437

This PR upgrade the Silences CRD which was updated last on Feb 13, 2023 but never deployed.

It does:

- Make the `targetTags` field optional.
- Add a new `issue_url` field.

```diff
--- monitoring.giantswarm.io_silences.yaml	2025-03-21 14:59:25.379075255 +0100
+++ monitoring.giantswarm.io_silences.yaml	2025-03-21 15:00:16.489114471 +0100
@@ -39,6 +39,9 @@
             type: object
           spec:
             properties:
+              issue_url:
+                description: IssueURL is a link to a GitHub issue describing the problem.
+                type: string
               matchers:
                 items:
                   properties:
@@ -61,8 +64,8 @@
                   owns the silence.
                 type: string
               postmortem_url:
-                description: PostmortemURL is a link to a document describing the
-                  problem.
+                description: 'PostmortemURL is a link to a document describing the
+                  problem. Deprecated: Use IssueURL instead.'
                 type: string
               targetTags:
                 items:
@@ -78,7 +81,6 @@
                 type: array
             required:
             - matchers
-            - targetTags
             type: object
         required:
         - metadata
```