### PR TITLE
Add gateway-api-bundle base to extras

### DIFF
--- a/extras/gateway-api-bundle/app.yaml
+++ b/extras/gateway-api-bundle/app.yaml
@@ -1,0 +1,19 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app.kubernetes.io/name: gateway-api-bundle
+    app-operator.giantswarm.io/version: 0.0.0
+  name: gateway-api-bundle
+  namespace: org-giantswarm
+spec:
+  catalog: giantswarm
+  kubeConfig:
+    inCluster: true
+  name: gateway-api-bundle
+  namespace: org-giantswarm
+  userConfig:
+    configMap:
+      name: gateway-api-bundle-user-values
+      namespace: org-giantswarm
+  version: 0.3.0

--- a/extras/gateway-api-bundle/configmap.yaml
+++ b/extras/gateway-api-bundle/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  values: |
+    organization: giantswarm
+kind: ConfigMap
+metadata:
+  name: gateway-api-bundle-user-values
+  namespace: org-giantswarm

--- a/extras/gateway-api-bundle/kustomization.yaml
+++ b/extras/gateway-api-bundle/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./configmap.yaml
+  - ./app.yaml
+
+configurations:
+  - nameReference.yaml

--- a/extras/gateway-api-bundle/nameReference.yaml
+++ b/extras/gateway-api-bundle/nameReference.yaml
@@ -1,0 +1,5 @@
+nameReference:
+  - kind: ConfigMap
+    fieldSpecs:
+      - kind: App
+        path: spec/userConfig/configMap/name


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Towards https://github.com/giantswarm/giantswarm/issues/32738

### Add base for the gateway-api-bundle

This extra can be used in CMB repos with some added config.