### PR TITLE
Automated silence migration

### DIFF
--- a/bases/silences/karpenter.yaml
+++ b/bases/silences/karpenter.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: karpentercannotregisternewnodes
+  annotations:
+    motivation: The alert is currently not working as expected
+    valid-until: "2025-06-01"
+    issue: https://github.com/giantswarm/giantswarm/issues/32502
+spec:
+  matchers:
+    - name: alertname
+      value: KarpenterCanNotRegisterNewNodes
+      isRegex: false

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,3 +1,4 @@
 namePrefix: common-
 resources:
   - karpenter.yaml
+  - metricforwardingerrors.yaml

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,2 +1,3 @@
 namePrefix: common-
-resources: []
+resources:
+  - karpenter.yaml

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - metricforwardingerrors.yaml
   - mf1.yaml
   - mf2.yaml
+  - mf3.yaml

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - karpenter.yaml
   - metricforwardingerrors.yaml
   - mf1.yaml
+  - mf2.yaml

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -2,3 +2,4 @@ namePrefix: common-
 resources:
   - karpenter.yaml
   - metricforwardingerrors.yaml
+  - mf1.yaml

--- a/bases/silences/metricforwardingerrors.yaml
+++ b/bases/silences/metricforwardingerrors.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: metricforwardingerrors
+  annotations:
+    issue: https://github.com/giantswarm/giantswarm/issues/32873
+    motivation: This alert is noisy and we are working on a fix.
+    valid-until: 2025-04-15
+spec:
+  matchers:
+    - name: alertname
+      value: MetricForwardingErrors
+      isRegex: false

--- a/bases/silences/mf1.yaml
+++ b/bases/silences/mf1.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  annotations:
+    issue: https://github.com/giantswarm/giantswarm/issues/32873
+    motivation: This alert is noisy and we are working on a fix.
+    valid-until: "2025-04-15"
+  creationTimestamp: "2025-03-25T11:55:02Z"
+  finalizers:
+    - operatorkit.giantswarm.io/silence-operator-silence-controller
+  generation: 4
+  name: metricforwardingerrors
+  resourceVersion: "1784877810"
+  uid: 6a92b0fa-3e92-4fce-909f-d553151cc21e
+spec:
+  matchers:
+    - name: alertname
+      value: MetricForwardingErrors
+    - isEqual: false
+      isRegex: false
+      name: alertname
+      value: Heartbeat
+    - isEqual: false
+      isRegex: false
+      name: all_pipelines
+      value: "true"

--- a/bases/silences/mf2.yaml
+++ b/bases/silences/mf2.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  annotations:
+    config.kubernetes.io/origin: |
+      path: metricforwardingerrors.yaml
+    issue: https://github.com/giantswarm/giantswarm/issues/32873
+    motivation: This alert is noisy and we are working on a fix.
+    valid-until: "2025-04-15"
+  creationTimestamp: "2025-03-25T11:55:02Z"
+  finalizers:
+    - operatorkit.giantswarm.io/silence-operator-silence-controller
+  generation: 5
+  labels:
+    kustomize.toolkit.fluxcd.io/name: silences
+    kustomize.toolkit.fluxcd.io/namespace: flux-giantswarm
+  name: metricforwardingerrors
+  resourceVersion: "1784890403"
+  uid: 6a92b0fa-3e92-4fce-909f-d553151cc21e
+spec:
+  matchers:
+    - isRegex: false
+      name: alertname
+      value: MetricForwardingErrors
+    - isEqual: false
+      isRegex: false
+      name: alertname
+      value: Heartbeat
+    - isEqual: false
+      isRegex: false
+      name: all_pipelines
+      value: "true"

--- a/bases/silences/mf3.yaml
+++ b/bases/silences/mf3.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  annotations:
+    config.kubernetes.io/origin: |
+      path: metricforwardingerrors.yaml
+    issue: https://github.com/giantswarm/giantswarm/issues/32873
+    motivation: This alert is noisy and we are working on a fix.
+    valid-until: "2025-04-15"
+  creationTimestamp: "2025-03-25T11:55:02Z"
+  finalizers:
+    - operatorkit.giantswarm.io/silence-operator-silence-controller
+  generation: 6
+  labels:
+    kustomize.toolkit.fluxcd.io/name: silences
+    kustomize.toolkit.fluxcd.io/namespace: flux-giantswarm
+  name: metricforwardingerrors
+  resourceVersion: "1784891704"
+  uid: 6a92b0fa-3e92-4fce-909f-d553151cc21e
+spec:
+  matchers:
+    - name: alertname
+      value: MetricForwardingErrors
+    - isEqual: false
+      isRegex: false
+      name: alertname
+      value: Heartbeat
+    - isEqual: false
+      isRegex: false
+      name: all_pipelines
+      value: "true"


### PR DESCRIPTION
This pull request replaces https://github.com/giantswarm/giantswarm-management-clusters/pull/1074
This pull request was created because a silence was changed in the [silences](https://github.com/giantswarm/silences) repository which is now deprecated, see [Silences](https://intranet.giantswarm.io/docs/observability/silences/) documentation for the new way to manage silences.

It was automatically created by the [migrate.sh](https://github.com/giantswarm/silences/blob/main/scripts/migrate.sh) script.

Please review and merge this pull request to deploy the updated Silences CRs.