### PR TITLE
Automated silence migration

### DIFF
--- a/bases/silences/karpenter.yaml
+++ b/bases/silences/karpenter.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: karpentercannotregisternewnodes
+  annotations:
+    motivation: The alert is currently not working as expected
+    valid-until: "2025-06-01"
+    issue: https://github.com/giantswarm/giantswarm/issues/32502
+spec:
+  matchers:
+    - name: alertname
+      value: KarpenterCanNotRegisterNewNodes
+      isRegex: false

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,3 +1,4 @@
 namePrefix: common-
 resources:
   - karpenter.yaml
+  - metricforwardingerrors.yaml

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,2 +1,3 @@
 namePrefix: common-
-resources: []
+resources:
+  - karpenter.yaml

--- a/bases/silences/metricforwardingerrors.yaml
+++ b/bases/silences/metricforwardingerrors.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: metricforwardingerrors
+  annotations:
+    issue: https://github.com/giantswarm/giantswarm/issues/32873
+    motivation: This alert is noisy and we are working on a fix.
+    valid-until: 2025-04-15
+spec:
+  matchers:
+    - name: alertname
+      value: MetricForwardingErrors
+      isRegex: false


### PR DESCRIPTION
This pull request replaces null
This pull request was created because a silence was changed in the [silences](https://github.com/giantswarm/silences) repository which is now deprecated, see [Silences](https://intranet.giantswarm.io/docs/observability/silences/) documentation for the new way to manage silences.

It was automatically created by the [migrate.sh](https://github.com/giantswarm/silences/blob/main/scripts/migrate.sh) script.

Please review and merge this pull request to deploy the updated Silences CRs.