### PR TITLE
Enable Silences pruning

### DIFF
--- a/bases/flux-giantswarm-resources/resource-kustomizations.yaml
+++ b/bases/flux-giantswarm-resources/resource-kustomizations.yaml
@@ -143,7 +143,7 @@ spec:
   interval: 5m
   # DO NOT use slashes in the comment to indicate the path, just "->".
   path: "./management-clusters/{replaced in management-clusters -> <MC_NAME> -> kustomization.yaml}/silences"
-  prune: false
+  prune: true
   retryInterval: 1m
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30437

Enable pruning of Silences to ensure deleted silences from GitOps repositories owned by the Silences kustomization are removed from the cluster.