### PR TITLE
Fix URL path to silence CRD

### DIFF
--- a/.github/actions/silences-validate/action.yaml
+++ b/.github/actions/silences-validate/action.yaml
@@ -47,7 +47,7 @@ runs:
       shell: bash
       run: |
         shopt -s globstar
-        kubectl create -f https://raw.githubusercontent.com/giantswarm/silence-operator/master/config/crd/monitoring.giantswarm.io_silences.yaml
+        kubectl create -f https://raw.githubusercontent.com/giantswarm/silence-operator/master/config/crd/bases/monitoring.giantswarm.io_silences.yaml
         for directory in ${{ inputs.directory_pattern }}; do
           echo "Validating silences CRs in $directory"
           kustomize build "$directory" --output "${directory}/resources.yaml"


### PR DESCRIPTION
This PR:

Fixes the path to the Silence CRD used in the silence validation action. This change was introduced here: https://github.com/giantswarm/silence-operator/pull/532/files#diff-aedeae47698303912d41fb91bf50fa79776b00d8dc20d12e713f9d69cff4775e
