### PR TITLE
Fix URL to Silence CRDs in silences-validate action

### DIFF
--- a/.github/actions/silences-validate/action.yaml
+++ b/.github/actions/silences-validate/action.yaml
@@ -47,7 +47,7 @@ runs:
       shell: bash
       run: |
         shopt -s globstar
-        kubectl create -f https://raw.githubusercontent.com/giantswarm/silence-operator/master/config/crd/bases/monitoring.giantswarm.io_silences.yaml
+        kubectl create -f https://raw.githubusercontent.com/giantswarm/silence-operator/master/config/crd/monitoring.giantswarm.io_silences.yaml
         for directory in ${{ inputs.directory_pattern }}; do
           echo "Validating silences CRs in $directory"
           kustomize build "$directory" --output "${directory}/resources.yaml"


### PR DESCRIPTION
Fixes the path to the Silence CRD used in the silence validation action. Previously fixed in https://github.com/giantswarm/management-cluster-bases/pull/227, but the path was changed (again) in https://github.com/giantswarm/silence-operator/pull/534.
