### PR TITLE
Add grafanaorganization crd

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - https://raw.githubusercontent.com/giantswarm/rbac-operator/v0.39.0/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
   - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.10.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
   - https://raw.githubusercontent.com/giantswarm/konfigure-operator/refs/tags/v0.3.1/config/crd/bases/konfigure.giantswarm.io_managementclusterconfigurations.yaml
+  - https://raw.githubusercontent.com/giantswarm/observability-operator/refs/tags/v0.29.0/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml


### PR DESCRIPTION
This pull request adds the GrafanaOrganization CRD in MCB to avoid issues with Grafana (creating CRs) and the Observability operator (deploying the CRD and depending on Grafana cert being there) depending on each other https://github.com/giantswarm/giantswarm/issues/32664

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
