### PR TITLE
Update Silence CI

### DIFF
--- a/.github/actions/silences-report-expired/silences-report-expired.sh
+++ b/.github/actions/silences-report-expired/silences-report-expired.sh
@@ -129,7 +129,7 @@ report() {
   # Create the git branch
   $DRY_RUN && echo "> dry run active, otherwise would run..."
   _run git checkout --quiet -b "$branch_name" "$start_branch"
-  _run git rm --quiet -- "${file}"
+  _run git rm --quiet -- "${directory}/${file}"
   if [ -f "$directory/$KUSTOMIZATION_FILENAME" ]; then
     filename="${file##*/}"
     _run "$YQ" -i  'del(.resources[] | select(. == "'"$filename"'"))' "$directory/$KUSTOMIZATION_FILENAME"

--- a/.github/actions/silences-report-expired/silences-report-expired.sh
+++ b/.github/actions/silences-report-expired/silences-report-expired.sh
@@ -9,7 +9,7 @@ DEFAULT_EXPIRATION="14 days"
 COMMIT_MESSAGE_PREFIX="remove expired silence - "
 PULL_REQUEST_BODY_EXPIRED="This pull request was automatically created using the $(basename $0) script.
 
-If you are assigned for review, this means you created a silence which is now expired based on the \`valid-until\` annotation, and has **been removed from AlertManager**.
+If you are assigned for review, this means you created a silence which is **now expired** based on the \`valid-until\` annotation, and has **been removed from AlertManager**.
 
 If this is correct, please approve this PR and make sure it is being merged. Otherwise, feel free to update or extend the \`valid-until\` annotation. See: https://intranet.giantswarm.io/docs/observability/silences/#when-to-delete-a-silence"
 PULL_REQUEST_BODY_SOON="This pull request was automatically created using the $(basename "$0") script.

--- a/.github/actions/silences-report-expired/silences-report-expired.sh
+++ b/.github/actions/silences-report-expired/silences-report-expired.sh
@@ -164,7 +164,7 @@ report() {
 
     [[ "$mode" == "expired" ]] && _run gh pr merge --squash --auto "$branch_name" || true
   fi
-
+  }
 main() {
   local DRY_RUN=false
   local reporting=false

--- a/.github/actions/silences-report-expired/silences-report-expired.sh
+++ b/.github/actions/silences-report-expired/silences-report-expired.sh
@@ -221,14 +221,14 @@ done
 
     # Handle expired: auto-merge
     for commit in "${expired[@]}"; do
-      file="$(echo "$commit" | $YQ e '.file' | sed "s|^$directory/||")"
+      file="$(echo "$commit" | $YQ e '.file')"
       commit_sha="$(echo "$commit" | $YQ e '.hash')"
       report "$file" "$directory" "$commit_sha" "$start_branch" "$repository_name" "expired"
     done
 
     # Handle expiring soon: no auto-merge
     for commit in "${expiring_soon[@]}"; do
-      file="$(echo "$commit" | $YQ e '.file' | sed "s|^$directory/||")"
+      file="$(echo "$commit" | $YQ e '.file')"
       commit_sha="$(echo "$commit" | $YQ e '.hash')"
       report "$file" "$directory" "$commit_sha" "$start_branch" "$repository_name" "soon"
     done

--- a/.github/actions/silences-report-expired/silences-report-expired.sh
+++ b/.github/actions/silences-report-expired/silences-report-expired.sh
@@ -221,14 +221,14 @@ done
 
     # Handle expired: auto-merge
     for commit in "${expired[@]}"; do
-      file="$(echo "$commit" | $YQ e '.file')"
+      file="$(echo "$commit" | $YQ e '.file' | sed "s|^$directory/||")"
       commit_sha="$(echo "$commit" | $YQ e '.hash')"
       report "$file" "$directory" "$commit_sha" "$start_branch" "$repository_name" "expired"
     done
 
     # Handle expiring soon: no auto-merge
     for commit in "${expiring_soon[@]}"; do
-      file="$(echo "$commit" | $YQ e '.file')"
+      file="$(echo "$commit" | $YQ e '.file' | sed "s|^$directory/||")"
       commit_sha="$(echo "$commit" | $YQ e '.hash')"
       report "$file" "$directory" "$commit_sha" "$start_branch" "$repository_name" "soon"
     done

--- a/.github/actions/silences-report-expired/silences-report-expired.sh
+++ b/.github/actions/silences-report-expired/silences-report-expired.sh
@@ -7,7 +7,7 @@ KUSTOMIZATION_FILENAME="kustomization.yaml"
 
 DEFAULT_EXPIRATION="14 days"
 COMMIT_MESSAGE_PREFIX="remove expired silence - "
-PULL_REQUEST_BODY_EXPIRED="This pull request was automatically created using the $(basename "$0") script.
+PULL_REQUEST_BODY_EXPIRED="This pull request was automatically created using the $(basename $0) script.
 
 If you are assigned for review, this means you created a silence which is now expired based on the \`valid-until\` annotation, and has **been removed from AlertManager**.
 
@@ -105,7 +105,6 @@ report() {
 
   # Map the git commit author to its github handle using github api
   userGithubHandle="$(gh api "/repos/${repository_name}/commits/${commit_sha}" -q '.author.login')"
-
 
   message="${COMMIT_MESSAGE_PREFIX}${file}"
 

--- a/.github/actions/silences-report-expired/silences-report-expired.sh
+++ b/.github/actions/silences-report-expired/silences-report-expired.sh
@@ -104,7 +104,7 @@ report() {
   userGithubHandle="$(gh api "/repos/${repository_name}/commits/${commit_sha}" -q '.author.login')"
 
   # Check if silence has a linked open issue and skip if yes
-  issue_url="$($YQ e '.metadata.annotations.issue' "$directory/$file")"
+  issue_url="$($YQ e '.metadata.annotations.issue' "$file")"
 
   if [[ -n "$issue_url" && "$issue_url" != "null" ]]; then
     issue_number=$(echo "$issue_url" | grep -oE '[0-9]+$')
@@ -129,7 +129,7 @@ report() {
   # Create the git branch
   $DRY_RUN && echo "> dry run active, otherwise would run..."
   _run git checkout --quiet -b "$branch_name" "$start_branch"
-  _run git rm --quiet -- "${directory}/${file}"
+  _run git rm --quiet -- "$file"
   if [ -f "$directory/$KUSTOMIZATION_FILENAME" ]; then
     filename="${file##*/}"
     _run "$YQ" -i  'del(.resources[] | select(. == "'"$filename"'"))' "$directory/$KUSTOMIZATION_FILENAME"

--- a/.github/workflows/silences-report-expired.yaml
+++ b/.github/workflows/silences-report-expired.yaml
@@ -3,7 +3,7 @@ name: Report expired silences
 on:
   schedule:
     # At 09:00 on Monday.
-    - cron:  '0 9 * * 1'
+    - cron:  '0 9 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/silences-report-expired.yaml
+++ b/.github/workflows/silences-report-expired.yaml
@@ -2,7 +2,7 @@ name: Report expired silences
 
 on:
   schedule:
-    # At 09:00 on Monday.
+    # Everyday at 09:00
     - cron:  '0 9 * * *'
   workflow_dispatch:
 

--- a/.github/workflows/silences-report-expired.yaml
+++ b/.github/workflows/silences-report-expired.yaml
@@ -12,6 +12,6 @@ jobs:
     name: Report expired silences
     steps:
       - uses: actions/checkout@v4
-      - uses: giantswarm/management-cluster-bases/.github/actions/silences-report-expired@main
+      - uses: giantswarm/management-cluster-bases/.github/actions/silences-report-expired@test-silence-expiry
         with:
           directory_pattern: 'bases/silences'

--- a/.github/workflows/silences-report-expired.yaml
+++ b/.github/workflows/silences-report-expired.yaml
@@ -12,6 +12,6 @@ jobs:
     name: Report expired silences
     steps:
       - uses: actions/checkout@v4
-      - uses: giantswarm/management-cluster-bases/.github/actions/silences-report-expired@test-silence-expiry
+      - uses: giantswarm/management-cluster-bases/.github/actions/silences-report-expired@main
         with:
           directory_pattern: 'bases/silences'

--- a/bases/silences/karpenter.yaml
+++ b/bases/silences/karpenter.yaml
@@ -1,13 +1,12 @@
 apiVersion: monitoring.giantswarm.io/v1alpha1
 kind: Silence
 metadata:
-  name: karpentercannotregisternewnodes
+  name: test-silence-for-workflow
   annotations:
-    motivation: The alert is currently not working as expected
-    valid-until: "2025-06-01"
-    issue: https://github.com/giantswarm/giantswarm/issues/32502
+    motivation: "This is a test silence created to verify the expiration workflow"
+    valid-until: "2025-05-16"
 spec:
   matchers:
     - name: alertname
-      value: KarpenterCanNotRegisterNewNodes
+      value: TestAlertForSilence
       isRegex: false

--- a/bases/silences/karpenter.yaml
+++ b/bases/silences/karpenter.yaml
@@ -1,12 +1,13 @@
 apiVersion: monitoring.giantswarm.io/v1alpha1
 kind: Silence
 metadata:
-  name: test-silence-for-workflow
+  name: karpentercannotregisternewnodes
   annotations:
-    motivation: "This is a test silence created to verify the expiration workflow"
-    valid-until: "2025-05-18"
+    motivation: The alert is currently not working as expected
+    valid-until: "2025-06-01"
+    issue: https://github.com/giantswarm/giantswarm/issues/32502
 spec:
   matchers:
     - name: alertname
-      value: TestAlertForSilence
+      value: KarpenterCanNotRegisterNewNodes
       isRegex: false

--- a/bases/silences/karpenter.yaml
+++ b/bases/silences/karpenter.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-silence-for-workflow
   annotations:
     motivation: "This is a test silence created to verify the expiration workflow"
-    valid-until: "2025-05-16"
+    valid-until: "2025-05-18"
 spec:
   matchers:
     - name: alertname


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27553

This PR updates the Silence-related CI job logic to ensure that silence removal PRs are opened ahead of the actual expiry date, introducing a buffer period of 2 days. This gives reviewers enough time to review and approve the removal before the silence expires.

It does:

- Detect the silences expiring in <2 days
- Automerge PRs when the silence has expired
