### PR TITLE
Silence noisy and unused alerts (keda and JobScrapingFailure)

### DIFF
--- a/bases/silences/jobscrapingfailure.yaml
+++ b/bases/silences/jobscrapingfailure.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: jobscrapingfailure
+  annotations:
+    motivation: We did a review of jobs failing everywhere, let's give teams time to manage them.
+    valid-until: "2025-07-29"
+spec:
+  matchers:
+    - name: alertname
+      value: JobScrapingFailure
+      isRegex: false

--- a/bases/silences/keda.yaml
+++ b/bases/silences/keda.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: kedaerrors
+  annotations:
+    motivation: We don't support keda yet, yet some customers-installed keda are alerting.
+    valid-until: "2025-07-29"
+spec:
+  matchers:
+    - name: alertname
+      value: KedaScale.*
+      isRegex: true

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,3 +1,5 @@
 namePrefix: common-
 resources:
+  - jobscrapingfailure.yaml
   - karpenter.yaml
+  - keda.yaml


### PR DESCRIPTION
These alerts (Keda and JobScrapingFailure alerts) are mostly ignored today, yet they pollute our slack notifications.
So let's silence them for a while.