### PR TITLE
Update silence operator crds

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -3,7 +3,8 @@ resources:
   - https://raw.githubusercontent.com/giantswarm/apiextensions-application/v0.6.2/config/crd/application.giantswarm.io_apps.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_catalogs.yaml
   - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_charts.yaml
-  - https://raw.githubusercontent.com/giantswarm/silence-operator/refs/tags/v0.14.0/config/crd/monitoring.giantswarm.io_silences.yaml
+  - https://raw.githubusercontent.com/giantswarm/silence-operator/refs/tags/v0.17.0/config/crd/bases/monitoring.giantswarm.io_silences.yaml
+  - https://raw.githubusercontent.com/giantswarm/silence-operator/refs/tags/v0.17.0/config/crd/bases/observability.giantswarm.io_silences.yaml
   - https://raw.githubusercontent.com/giantswarm/organization-operator/v2.0.1/config/crd/bases/security.giantswarm.io_organizations.yaml
   - https://raw.githubusercontent.com/giantswarm/rbac-operator/v0.39.0/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
   - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.10.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml


### PR DESCRIPTION
## Some hints on changes to this repository

This is dependent on this PR https://github.com/giantswarm/silence-operator/pull/544

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

This pull request updates the `resources` section in the `bases/crds/giantswarm/kustomization.yaml` file to include newer versions of CRD definitions and adds a new CRD for observability silences.

### Updates to CRD resources:
* Updated the `silence-operator` CRD for monitoring silences to version `v0.17.0` and adjusted its path.
* Added a new CRD for observability silences from the `silence-operator` version `v0.17.0`.
