### PR TITLE
Add EOL date for K8s 1.33

### DIFF
--- a/extras/backstage/main/shared-config.yaml
+++ b/extras/backstage/main/shared-config.yaml
@@ -89,3 +89,6 @@ data:
         "1.32":
           minorVersion: "1.32"
           eolDate: 2026-02-28
+        "1.33":
+          minorVersion: "1.33"
+          eolDate: 2026-06-28


### PR DESCRIPTION
Source: https://kubernetes.io/releases/