### PR TITLE
Update Backstage shared config

### DIFF
--- a/extras/backstage/main/shared-config.yaml
+++ b/extras/backstage/main/shared-config.yaml
@@ -18,7 +18,7 @@ data:
         alertsDashboard:
           label: Alerts
           icon: NotificationsNone
-          url: "https://grafana.$${{BASE_DOMAIN}}/alerting"
+          url: "https://grafana.$${{BASE_DOMAIN}}/alerting?orgId=2"
         webUIWC:
           label: Web UI
           icon: Public


### PR DESCRIPTION
Grafana alerts link was fixed with the correct `orgId` parameter.