### PR TITLE
fix: use admin auth policy for zot

### DIFF
--- a/extras/zot-cache/values.yaml
+++ b/extras/zot-cache/values.yaml
@@ -112,21 +112,12 @@ configFiles:
                 {
                   "**":
                   {
-                      "anonymousPolicy": ["read"],
-                      "policies":
-                      [
-                          {
-                              "users": ["admin"],
-                              "actions":
-                              [
-                                  "read",
-                                  "create",
-                                  "update",
-                                  "delete"
-                              ]
-                          }
-                      ]
+                      "anonymousPolicy": ["read"]
                   }
+                },
+                "adminPolicy": {
+                  "users": ["admin"],
+                  "actions": ["read", "create", "update", "delete"]
                 }
             },
             "address": "0.0.0.0",


### PR DESCRIPTION
The previous policy was giving the `admin` user a full CRUD to all repositories, but it's not the same as `adminPolicy`, which also grants permissions to extra endpoints, like performance and profiling.