### PR TITLE
Ignore alert `ClusterControlPlaneMachineStatusNotHealthy` for now since it accidentally alerts for test clusters

### DIFF
--- a/bases/silences/clustercontrolplanemachinestatusnothealthy.yaml
+++ b/bases/silences/clustercontrolplanemachinestatusnothealthy.yaml
@@ -1,0 +1,17 @@
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: clustercontrolplanemachinestatusnothealthy
+  namespace: monitoring
+  annotations:
+    motivation: The alert is currently not working as expected
+    valid-until: "2025-08-14"
+    issue: https://github.com/giantswarm/giantswarm/issues/34025
+spec:
+  matchers:
+    - name: alertname
+      value: ClusterControlPlaneMachineStatusNotHealthy
+      matchType: "="
+    - name: cluster_id
+      value: ".*"
+      matchType: "=~"

--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,3 +1,4 @@
 namePrefix: common-
 resources:
+  - clustercontrolplanemachinestatusnothealthy.yaml
   - jobscrapingfailure.yaml


### PR DESCRIPTION
See https://github.com/giantswarm/giantswarm/issues/34025

