### PR TITLE
chg: upgrade zot to 2.3.1

### DIFF
--- a/extras/zot-cache/helm-release.yaml
+++ b/extras/zot-cache/helm-release.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: giantswarm-catalog
         namespace: flux-giantswarm
-      version: 2.3.0
+      version: 2.3.1
   install:
     remediation:
       retries: 10

--- a/extras/zot-cache/values.yaml
+++ b/extras/zot-cache/values.yaml
@@ -34,10 +34,10 @@ giantswarm:
 resources:
   requests:
     cpu: 300m
-    memory: 1024Mi
+    memory: 1536Mi
   limits:
-    cpu: 500m
-    memory: 1024Mi
+    cpu: 800m
+    memory: 1536Mi
 
 env:
   - name: "GOGC"

--- a/extras/zot-cache/values.yaml
+++ b/extras/zot-cache/values.yaml
@@ -43,7 +43,7 @@ env:
   - name: "GOGC"
     value: "50"
   - name: "GOMEMLIMIT"
-    value: "800MiB"
+    value: "1200MiB"
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
- upgrade zot to giantswarm release 2.3.1
- increase zot CPU limit to 800m and mem R/L to 1536M