### PR TITLE
chg: zot config tuning

### DIFF
--- a/extras/zot-cache/values.yaml
+++ b/extras/zot-cache/values.yaml
@@ -54,12 +54,12 @@ configFiles:
     {
         "storage":
         {
-            "rootDirectory": "/var/lib/registry",
-            "dedupe": true,
-            "gc": true,
-            "gcDelay": "1h",
-            "gcInterval": "24h",
-            "retention": {
+          "rootDirectory": "/var/lib/registry",
+          "dedupe": false,
+          "gc": true,
+          "gcInterval": "24h",
+          "retention": 
+          {
             "dryRun": false,
             "policies": [
               {
@@ -121,7 +121,7 @@ configFiles:
                   "users": ["admin"],
                   "actions": ["read", "create", "update", "delete"]
                 }
-            },
+              },
             "address": "0.0.0.0",
             "port": "5000"
         },
@@ -146,7 +146,8 @@ configFiles:
             ]
           },
           "scrub": {
-            "enable": true
+            "enable": true,
+            "interval": "24h"
           },
           "ui": {
             "enable": false


### PR DESCRIPTION
This PR:
- disables initial garbage collection and leaves only the periodic one
- disables deduplication on data to limit the risk of storage locks (should result in better performance, but bigger storage usage)
- configures scrubbing to run every 24h (instead of the default 2h)