### PR TITLE
Update "Validate manifests" workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Lint kustomization.yaml
+      - name: List kustomizations
+        uses: docker://gsoci.azurecr.io/giantswarm/yamllint:1.0.0
+        with:
+          args: --list-files management-clusters
+
+      - name: Lint kustomizations
         uses: docker://gsoci.azurecr.io/giantswarm/yamllint:1.0.0
         with:
           args: --format=github management-clusters


### PR DESCRIPTION
- Use up-to-date yamllint image
- Set `--format=github` to improve output
- Add steps to list files to lint
- Update actions/checkout and pin the version

An example PR using these change scan be seen here:

https://github.com/giantswarm/giantswarm-management-clusters/pull/1347

Example workflow run:

https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/16987903756/job/48161264649