### PR TITLE
Remove trigger "push" from "Validate silences" workflow

### DIFF
--- a/.github/workflows/silences-validate.yaml
+++ b/.github/workflows/silences-validate.yaml
@@ -1,7 +1,9 @@
 name: Validate silences
 
 on:
-  - pull_request
+  pull_request:
+    paths:
+      - '**.yaml'
 
 jobs:
   silences_validate:

--- a/.github/workflows/silences-validate.yaml
+++ b/.github/workflows/silences-validate.yaml
@@ -1,6 +1,7 @@
 name: Validate silences
 
-on: [push, pull_request]
+on:
+  - pull_request
 
 jobs:
   silences_validate:


### PR DESCRIPTION
The Validate silences workflow is triggered twice for every pull request, once by the `push` trigger and once by the `pull_request` trigger.

This PR removes the `push` trigger. As a consequence, the check will not happen on all pushes, only those related to a PR.