### PR TITLE
Bump caicloud-event-exporter to v0.2.3

### DIFF
--- a/extras/crossplane/helmrelease-event-exporter.yaml
+++ b/extras/crossplane/helmrelease-event-exporter.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: giantswarm-control-plane-catalog
         namespace: flux-giantswarm
-      version: 0.2.2
+      version: 0.2.3
   install:
     remediation:
       retries: 10


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3935

This updates caicloud-event-exporter to avoid pulling its image from a deprecated registry.