### PR TITLE
chg: upgrade zot to 2.3.3 (upstream 2.1.8 with concurrency fix)

### DIFF
--- a/extras/zot-cache/helm-release.yaml
+++ b/extras/zot-cache/helm-release.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: giantswarm-catalog
         namespace: flux-giantswarm
-      version: 2.3.1
+      version: 2.3.3
   install:
     remediation:
       retries: 10


### PR DESCRIPTION
as in title