### PR TITLE
Bump KFG and KFGS konfigure-operator CRDs to v1.0.0

### DIFF
--- a/bases/crds/giantswarm/kustomization.yaml
+++ b/bases/crds/giantswarm/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
   - https://raw.githubusercontent.com/giantswarm/rbac-operator/v0.39.0/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
   - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.10.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
   - https://raw.githubusercontent.com/giantswarm/konfigure-operator/refs/tags/v0.9.0/config/crd/bases/konfigure.giantswarm.io_managementclusterconfigurations.yaml
-  - https://raw.githubusercontent.com/giantswarm/konfigure-operator/refs/tags/v0.9.0/config/crd/bases/konfigure.giantswarm.io_konfigurationschemas.yaml
-  - https://raw.githubusercontent.com/giantswarm/konfigure-operator/refs/tags/v0.9.0/config/crd/bases/konfigure.giantswarm.io_konfigurations.yaml
+  - https://raw.githubusercontent.com/giantswarm/konfigure-operator/refs/tags/v1.0.0/config/crd/bases/konfigure.giantswarm.io_konfigurationschemas.yaml
+  - https://raw.githubusercontent.com/giantswarm/konfigure-operator/refs/tags/v1.0.0/config/crd/bases/konfigure.giantswarm.io_konfigurations.yaml
   - https://raw.githubusercontent.com/giantswarm/observability-operator/main/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml


### PR DESCRIPTION
MCC will be removed later when collections removed their references to it.