### PR TITLE
chg: delete vintage CRDs from bases

### DIFF
--- a/bases/crds/vintage/aws/v5.2.0/kustomization.yaml
+++ b/bases/crds/vintage/aws/v5.2.0/kustomization.yaml
@@ -1,9 +1,0 @@
-resources:
-  - ../../common
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/core.giantswarm.io_awsclusterconfigs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awsclusters.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awscontrolplanes.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awsmachinedeployments.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/infrastructure.giantswarm.io_g8scontrolplanes.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/infrastructure.giantswarm.io_networkpools.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v5.2.0/helm/crds-aws/templates/provider.giantswarm.io_awsconfigs.yaml

--- a/bases/crds/vintage/aws/v6.6.0/kustomization.yaml
+++ b/bases/crds/vintage/aws/v6.6.0/kustomization.yaml
@@ -1,9 +1,0 @@
-resources:
-  - ../../common
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/core.giantswarm.io_awsclusterconfigs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awsclusters.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awscontrolplanes.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/infrastructure.giantswarm.io_awsmachinedeployments.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/infrastructure.giantswarm.io_g8scontrolplanes.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/infrastructure.giantswarm.io_networkpools.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-aws/templates/provider.giantswarm.io_awsconfigs.yaml

--- a/bases/crds/vintage/azure/v6.6.0/kustomization.yaml
+++ b/bases/crds/vintage/azure/v6.6.0/kustomization.yaml
@@ -1,6 +1,0 @@
-resources:
-  - ../../common
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-azure/templates/core.giantswarm.io_azureclusterconfigs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-azure/templates/exp.cluster.x-k8s.io_machinepools.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-azure/templates/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-azure/templates/provider.giantswarm.io_azureconfigs.yaml

--- a/bases/crds/vintage/common/kustomization.yaml
+++ b/bases/crds/vintage/common/kustomization.yaml
@@ -1,8 +1,0 @@
-resources:
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/application.giantswarm.io_appcatalogs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_certconfigs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_chartconfigs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_configs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_drainerconfigs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_sparks.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-common/templates/core.giantswarm.io_storageconfigs.yaml

--- a/bases/crds/vintage/kvm/v6.6.0/kustomization.yaml
+++ b/bases/crds/vintage/kvm/v6.6.0/kustomization.yaml
@@ -1,5 +1,0 @@
-resources:
-  - ../../common
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-kvm/templates/core.giantswarm.io_flannelconfigs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-kvm/templates/core.giantswarm.io_kvmclusterconfigs.yaml
-  - https://raw.githubusercontent.com/giantswarm/apiextensions/v6.6.0/helm/crds-kvm/templates/provider.giantswarm.io_kvmconfigs.yaml


### PR DESCRIPTION
These should not be needed anymore.