### PR TITLE
Update Crossplane Upbound AWS provider Kyverno Polex to v2

### DIFF
--- a/extras/crossplane/providers/upbound/aws/polex.yaml
+++ b/extras/crossplane/providers/upbound/aws/polex.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: PolicyException
 metadata:
   name: crossplane-upbound-provider


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/34102

This is safe to do as all MCs have this version already.