### PR TITLE
Bump external-secrets to v0.18.3

### DIFF
--- a/extras/external-secrets/helmrelease-external-secrets.yaml
+++ b/extras/external-secrets/helmrelease-external-secrets.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: giantswarm-catalog
         namespace: flux-giantswarm
-      version: 0.18.2
+      version: 0.18.3
   install:
     remediation:
       retries: 10


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/34102