### PR TITLE
Disable Flux pruning for AWS Crossplane compositions

### DIFF
--- a/bases/collections/capa/base/patches/konfiguration.yaml
+++ b/bases/collections/capa/base/patches/konfiguration.yaml
@@ -27,3 +27,11 @@ spec:
         variables:
           - name: app
             value: cluster-api-provider-aws
+      crossplane-fn-irsa:
+        variables:
+          - name: app
+            value: crossplane-fn-irsa
+      crossplane-fn-mcoidc:
+        variables:
+          - name: app
+            value: crossplane-fn-mcoidc

--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   interval: 30s
   ref:
-    branch: crossplane-functions
+    branch: main
   secretRef:
     name: shared-configs-ssh-credentials
   timeout: 60s

--- a/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
+++ b/bases/flux-giantswarm-resources/resource-gitrepositories.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   interval: 30s
   ref:
-    branch: main
+    branch: crossplane-functions
   secretRef:
     name: shared-configs-ssh-credentials
   timeout: 60s

--- a/extras/crossplane/compositions/aws/kustomization.yaml
+++ b/extras/crossplane/compositions/aws/kustomization.yaml
@@ -1,3 +1,6 @@
 resources:
 - https://github.com/giantswarm/crossplane-fn-irsa//api/composition?ref=main
 - https://github.com/giantswarm/crossplane-fn-mcoidc//api/composition?ref=main
+
+commonAnnotations:
+  kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary
- Adds `kustomize.toolkit.fluxcd.io/prune: disabled` via `commonAnnotations` to `extras/crossplane/compositions/aws/kustomization.yaml`.
- Prep step so the Compositions rendered here can be removed from the GitOps repo in a follow-up without Flux garbage-collecting them from the cluster.
- Generate the konfiguration needed by both Crossplane function Helm charts

- [ ] Requires https://github.com/giantswarm/shared-configs/pull/618 to be merged first.

Towards https://github.com/giantswarm/giantswarm/issues/35685

## Test plan
- [ ] Merge this PR and wait for Flux to reconcile.
- [ ] Verify the annotation is present on the live Composition objects (`kubectl get composition ... -o yaml`).
- [ ] Open the follow-up PR that removes the entries and confirm the objects remain in the cluster after reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)