### PR TITLE
Update observability operator CRD resources to version 0.68.0

### DIFF
--- a/bases/crds/giantswarm/stages/testing/observability-bundle/kustomization.yaml
+++ b/bases/crds/giantswarm/stages/testing/observability-bundle/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
-  - https://raw.githubusercontent.com/giantswarm/observability-operator/refs/tags/v0.54.0/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
+  - https://raw.githubusercontent.com/giantswarm/observability-operator/refs/tags/v0.68.0/config/crd/bases/observability.giantswarm.io_agentcredentials.yaml
+  - https://raw.githubusercontent.com/giantswarm/observability-operator/refs/tags/v0.68.0/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml


### PR DESCRIPTION
Update and apply the new observability operator CRDs. This needs to be merged before this PR is released https://github.com/giantswarm/observability-operator/pull/794