### PR TITLE
silence olly-op reconciliation alerts

### DIFF
--- a/bases/silences/kustomization.yaml
+++ b/bases/silences/kustomization.yaml
@@ -1,3 +1,4 @@
 namePrefix: common-
 resources:
   - mimir-ruler-evaluation-failures.yaml
+  - olly-op-reconciliations.yaml

--- a/bases/silences/olly-op-reconciliations.yaml
+++ b/bases/silences/olly-op-reconciliations.yaml
@@ -1,0 +1,16 @@
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: ollyopreconciliations
+  namespace: monitoring
+  annotations:
+    motivation: Observability-operator upgrade may generate temporary alerts
+    valid-until: 2026-04-28
+spec:
+  matchers:
+    - name: alertname
+      value: "AtlasOperatorsReconciliationError"
+      matchType: "="
+    - name: cluster_id
+      value: ".*"
+      matchType: "=~"


### PR DESCRIPTION
Observability-operator release 0.68.0 will generate some reconciliation errors and may trigger alerts. So let's silence it during the release.

The reason is the operator depends on new CRDs that will be deployed by https://github.com/giantswarm/management-cluster-bases/pull/544, but will only be available when observability-operator is released.