### PR TITLE
Install irsa and mcoidc Crossplane functions via their Helm chart in the capa collection

### DIFF
--- a/bases/collections/capa/base/crossplane-fn-irsa.yaml
+++ b/bases/collections/capa/base/crossplane-fn-irsa.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: crossplane-fn-irsa
+  namespace: giantswarm
+spec:
+  interval: 10m
+  provider: generic
+  ref:
+    semver: x.x.x
+  url: oci://gsoci.azurecr.io/charts/giantswarm/crossplane-fn-irsa
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: crossplane-fn-irsa
+  namespace: giantswarm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: crossplane-fn-irsa
+    namespace: giantswarm
+  install:
+    remediation:
+      remediateLastFailure: false
+      retries: 10
+  interval: 5m
+  releaseName: crossplane-fn-irsa
+  storageNamespace: org-giantswarm
+  targetNamespace: org-giantswarm
+  timeout: 10m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 10
+      strategy: rollback
+  valuesFrom:
+    - kind: ConfigMap
+      name: crossplane-fn-irsa-konfiguration
+      valuesKey: configmap-values.yaml
+    - kind: Secret
+      name: crossplane-fn-irsa-konfiguration
+      valuesKey: secret-values.yaml

--- a/bases/collections/capa/base/crossplane-fn-mcoidc.yaml
+++ b/bases/collections/capa/base/crossplane-fn-mcoidc.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: crossplane-fn-mcoidc
+  namespace: giantswarm
+spec:
+  interval: 10m
+  provider: generic
+  ref:
+    semver: x.x.x
+  url: oci://gsoci.azurecr.io/charts/giantswarm/crossplane-fn-mcoidc
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: crossplane-fn-mcoidc
+  namespace: giantswarm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: crossplane-fn-mcoidc
+    namespace: giantswarm
+  install:
+    remediation:
+      remediateLastFailure: false
+      retries: 10
+  interval: 5m
+  releaseName: crossplane-fn-mcoidc
+  storageNamespace: org-giantswarm
+  targetNamespace: org-giantswarm
+  timeout: 10m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 10
+      strategy: rollback
+  valuesFrom:
+    - kind: ConfigMap
+      name: crossplane-fn-mcoidc-konfiguration
+      valuesKey: configmap-values.yaml
+    - kind: Secret
+      name: crossplane-fn-mcoidc-konfiguration
+      valuesKey: secret-values.yaml

--- a/bases/collections/capa/base/kustomization.yaml
+++ b/bases/collections/capa/base/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - aws-vpc-operator.yaml
   - capa-iam-operator.yaml
   - cluster-api-provider-aws.yaml
+  - crossplane-fn-irsa.yaml
+  - crossplane-fn-mcoidc.yaml

--- a/extras/crossplane/compositions/aws/kustomization.yaml
+++ b/extras/crossplane/compositions/aws/kustomization.yaml
@@ -1,6 +1,4 @@
-resources:
-- https://github.com/giantswarm/crossplane-fn-irsa//api/composition?ref=main
-- https://github.com/giantswarm/crossplane-fn-mcoidc//api/composition?ref=main
+resources: []
 
 commonAnnotations:
   kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Now that the kustomization resources are removed, they must be installed via helm

Towards https://github.com/giantswarm/giantswarm/issues/35685
