### PR TITLE
Add mcp-runbooks extra base

### DIFF
--- a/extras/mcp-runbooks/README.md
+++ b/extras/mcp-runbooks/README.md
@@ -1,0 +1,77 @@
+# MCP Runbooks
+
+## Description
+
+MCP Runbooks server provides Giant Swarm operational runbooks over the Model
+Context Protocol (streamable HTTP transport). Runbooks are embedded in the
+container image at build time.
+
+## Usage
+
+Reference this extra in your cluster's extras:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/giantswarm/management-cluster-bases//extras/mcp-runbooks?ref=main
+```
+
+No per-cluster secrets are required.
+
+## Version Strategy
+
+Auto-updates enabled via SemVer range `>=0.0.0`. New versions deploy
+automatically when pushed to the OCI registry.
+
+## Deploying to a Cluster
+
+### 1. Create the cluster extras directory
+
+```bash
+mkdir -p <customer>-management-clusters/management-clusters/<mc>/extras/mcp-runbooks
+```
+
+### 2. Create the kustomization
+
+Create `<customer>-management-clusters/management-clusters/<mc>/extras/mcp-runbooks/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/giantswarm/management-cluster-bases//extras/mcp-runbooks?ref=main
+```
+
+### 3. Add to the extras kustomization
+
+Add to `<customer>-management-clusters/management-clusters/<mc>/extras/kustomization.yaml`:
+
+```yaml
+resources:
+  # ... existing extras ...
+  - ./mcp-runbooks/
+```
+
+## Troubleshooting
+
+### OCIRepository Not Ready
+
+```bash
+kubectl get ocirepository mcp-runbooks -n flux-giantswarm
+kubectl describe ocirepository mcp-runbooks -n flux-giantswarm
+```
+
+### HelmRelease Issues
+
+```bash
+kubectl get helmrelease mcp-runbooks -n flux-giantswarm
+kubectl describe helmrelease mcp-runbooks -n flux-giantswarm
+```
+
+### Pod Issues
+
+```bash
+kubectl get pods -n mcp-runbooks
+kubectl logs -n mcp-runbooks -l app.kubernetes.io/name=mcp-runbooks
+```

--- a/extras/mcp-runbooks/helm-release.yaml
+++ b/extras/mcp-runbooks/helm-release.yaml
@@ -1,0 +1,34 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mcp-runbooks
+  namespace: flux-giantswarm
+spec:
+  # Explicitly set release name to avoid Flux generating a prefixed name
+  # when targetNamespace differs from HelmRelease namespace
+  releaseName: mcp-runbooks
+  chartRef:
+    kind: OCIRepository
+    name: mcp-runbooks
+    namespace: flux-giantswarm
+  install:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  interval: 10m
+  targetNamespace: mcp-runbooks
+  timeout: 10m
+  upgrade:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  values:
+    image:
+      repository: gsociprivate.azurecr.io/giantswarm/mcp-runbooks
+    mcp:
+      transport: http
+      addr: ":8080"
+    runbooks:
+      # Use runbooks embedded in the image rather than a ConfigMap
+      useConfigMap: false
+      path: /app/runbooks

--- a/extras/mcp-runbooks/kustomization.yaml
+++ b/extras/mcp-runbooks/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./namespace.yaml
+  - ./oci-repository.yaml
+  - ./helm-release.yaml

--- a/extras/mcp-runbooks/namespace.yaml
+++ b/extras/mcp-runbooks/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-runbooks

--- a/extras/mcp-runbooks/oci-repository.yaml
+++ b/extras/mcp-runbooks/oci-repository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: mcp-runbooks
+  namespace: flux-giantswarm
+spec:
+  interval: 10m
+  url: oci://gsoci.azurecr.io/charts/giantswarm/mcp-runbooks
+  ref:
+    # Auto-update: deploy latest version automatically
+    semver: ">=0.0.0"
+  provider: generic


### PR DESCRIPTION
## Summary

- Adds a Flux base under `extras/mcp-runbooks/` for deploying [mcp-runbooks](https://github.com/giantswarm/mcp-runbooks).
- Ships namespace, OCIRepository (semver auto-update from `oci://gsoci.azurecr.io/charts/giantswarm/mcp-runbooks`), and HelmRelease with streamable HTTP transport and image-embedded runbooks.
- No per-cluster secrets or Konfiguration needed (chart has no auth/session storage requirements).

Refs giantswarm/giantswarm#36381 — companion PR in `giantswarm-management-clusters` wires this into gazelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)