### PR TITLE
Switch mcp-runbooks to Konfigure-rendered values with pull secret support

### DIFF
--- a/extras/mcp-runbooks/README.md
+++ b/extras/mcp-runbooks/README.md
@@ -15,14 +15,43 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/giantswarm/management-cluster-bases//extras/mcp-runbooks?ref=main
+  - pull-secret.enc.yaml
 ```
 
-No per-cluster secrets are required.
+## Configuration
+
+- **Templates**: `shared-configs/default/apps/mcp-runbooks/`
+- **Secrets**: Inline Kubernetes Secrets in `<customer>-management-clusters/management-clusters/<mc>/extras/mcp-runbooks/`
 
 ## Version Strategy
 
 Auto-updates enabled via SemVer range `>=0.0.0`. New versions deploy
 automatically when pushed to the OCI registry.
+
+## Prerequisites
+
+For the Konfiguration to work, the `flux-extras` Kustomization must pass the `cluster_name` variable.
+
+Add this target to the `replacements` section in `<customer>-management-clusters/management-clusters/<cluster>/kustomization.yaml`:
+
+```yaml
+replacements:
+  - source:
+      kind: ConfigMap
+      name: management-cluster-metadata
+      namespace: flux-giantswarm
+      fieldPath: data.NAME
+    targets:
+      # ... existing targets ...
+      - select:
+          kind: Kustomization
+          name: flux-extras
+          namespace: flux-giantswarm
+        fieldPaths:
+          - spec.postBuild.substitute.cluster_name
+        options:
+          create: true
+```
 
 ## Deploying to a Cluster
 
@@ -41,9 +70,32 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/giantswarm/management-cluster-bases//extras/mcp-runbooks?ref=main
+  - pull-secret.enc.yaml
 ```
 
-### 3. Add to the extras kustomization
+### 3. Create the image pull secret
+
+Create `pull-secret.enc.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-runbooks-pull-secret
+  namespace: mcp-runbooks
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: "your-dockerconfigjson"
+```
+
+Encrypt with SOPS:
+
+```bash
+export SOPS_AGE_KEY="op://Dev Common/<mc>.agekey/notesPlain"
+op run -- sops -e -i pull-secret.enc.yaml
+```
+
+### 4. Add to the extras kustomization
 
 Add to `<customer>-management-clusters/management-clusters/<mc>/extras/kustomization.yaml`:
 
@@ -60,6 +112,13 @@ resources:
 ```bash
 kubectl get ocirepository mcp-runbooks -n flux-giantswarm
 kubectl describe ocirepository mcp-runbooks -n flux-giantswarm
+```
+
+### Konfiguration Not Creating ConfigMap
+
+```bash
+kubectl get konfiguration mcp-runbooks-konfiguration -n flux-giantswarm
+kubectl logs -n flux-giantswarm deployment/konfiguration-controller
 ```
 
 ### HelmRelease Issues

--- a/extras/mcp-runbooks/helm-release.yaml
+++ b/extras/mcp-runbooks/helm-release.yaml
@@ -22,13 +22,8 @@ spec:
     remediation:
       retries: 10
       remediateLastFailure: false
-  values:
-    image:
-      repository: gsociprivate.azurecr.io/giantswarm/mcp-runbooks
-    mcp:
-      transport: http
-      addr: ":8080"
-    runbooks:
-      # Use runbooks embedded in the image rather than a ConfigMap
-      useConfigMap: false
-      path: /app/runbooks
+  valuesFrom:
+    # ConfigMap rendered by Konfiguration from shared-configs template
+    - kind: ConfigMap
+      name: mcp-runbooks-konfiguration
+      valuesKey: configmap-values.yaml

--- a/extras/mcp-runbooks/konfiguration.yaml
+++ b/extras/mcp-runbooks/konfiguration.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: konfigure.giantswarm.io/v1alpha1
+kind: Konfiguration
+metadata:
+  name: mcp-runbooks-konfiguration
+  namespace: flux-giantswarm
+spec:
+  targets:
+    schema:
+      reference:
+        name: management-cluster-configuration
+        namespace: giantswarm
+    defaults:
+      variables:
+        - name: installation
+          value: "${cluster_name}"
+    iterations:
+      mcp-runbooks:
+        variables:
+          - name: app
+            value: mcp-runbooks
+  destination:
+    namespace: flux-giantswarm
+    naming:
+      suffix: konfiguration
+  reconciliation:
+    interval: 1m
+    retryInterval: 10s
+    suspend: false
+  sources:
+    flux:
+      gitRepository:
+        name: "giantswarm-config"
+        namespace: "flux-giantswarm"

--- a/extras/mcp-runbooks/kustomization.yaml
+++ b/extras/mcp-runbooks/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./namespace.yaml
   - ./oci-repository.yaml
   - ./helm-release.yaml
+  - ./konfiguration.yaml


### PR DESCRIPTION
## Summary
- Move `mcp-runbooks` HelmRelease from inline `values:` to a Konfiguration-rendered ConfigMap (`mcp-runbooks-konfiguration`), mirroring `mcp-kubernetes`.
- Add `konfiguration.yaml` sourcing from the `giantswarm-config` git repo (iteration `mcp-runbooks`).
- Update README to document the new pattern and the per-installation `pull-secret.enc.yaml` workflow.

## Follow-ups (out of scope for this PR)
- Add the `mcp-runbooks` template under `giantswarm-configs/default/apps/mcp-runbooks/` providing the previous inline values plus `imagePullSecrets`.
- Per-installation `pull-secret.enc.yaml` (e.g. for `gazelle`) is added in the per-customer management-clusters repo.
