### PR TITLE
Switch mcp-runbooks OCIRepository to gsociprivate registry

### DIFF
--- a/extras/mcp-runbooks/oci-repository.yaml
+++ b/extras/mcp-runbooks/oci-repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-giantswarm
 spec:
   interval: 10m
-  url: oci://gsoci.azurecr.io/charts/giantswarm/mcp-runbooks
+  url: oci://gsociprivate.azurecr.io/giantswarm/mcp-runbooks
   ref:
     # Auto-update: deploy latest version automatically
     semver: ">=0.0.0"


### PR DESCRIPTION
## Summary
- Point the mcp-runbooks `OCIRepository` at `oci://gsociprivate.azurecr.io/giantswarm/mcp-runbooks` so the chart pull matches the image pull location already configured via `shared-configs`.
- The previous public URL (`gsoci.azurecr.io/charts/giantswarm/mcp-runbooks`) returns `NAME_UNKNOWN` — the chart is only published to the private registry.
