### PR TITLE
Add secretRef to mcp-runbooks OCIRepository

### DIFF
--- a/extras/mcp-runbooks/oci-repository.yaml
+++ b/extras/mcp-runbooks/oci-repository.yaml
@@ -10,3 +10,5 @@ spec:
     # Auto-update: deploy latest version automatically
     semver: ">=0.0.0"
   provider: generic
+  secretRef:
+    name: mcp-runbooks-flux-pull-secret


### PR DESCRIPTION
## Summary
- The mcp-runbooks chart lives on `gsociprivate.azurecr.io` (private). Without auth, the OCIRepository fails with `UNAUTHORIZED: authentication required`.
- Reference a `dockerconfigjson` secret named `mcp-runbooks-flux-pull-secret` in `flux-giantswarm`. The secret is provisioned per-MC by the gazelle extras kustomization.
