### PR TITLE
Point mcp-runbooks OCIRepository at the chart path

### DIFF
--- a/extras/mcp-runbooks/oci-repository.yaml
+++ b/extras/mcp-runbooks/oci-repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-giantswarm
 spec:
   interval: 10m
-  url: oci://gsociprivate.azurecr.io/giantswarm/mcp-runbooks
+  url: oci://gsociprivate.azurecr.io/charts/giantswarm/mcp-runbooks
   ref:
     # Auto-update: deploy latest version automatically
     semver: ">=0.0.0"


### PR DESCRIPTION
## Summary
- Update the `OCIRepository` URL from `oci://gsociprivate.azurecr.io/giantswarm/mcp-runbooks` (image path) to `oci://gsociprivate.azurecr.io/charts/giantswarm/mcp-runbooks` (chart path).
- The image and chart are published to different paths on the private registry; the previous URL fetched a non-Helm artifact and helm-controller failed with `Chart.yaml file is missing`.
