### PR TITLE
disable secure metrics endpoint for k6-operator

### DIFF
--- a/extras/k6-operator/configmap.yaml
+++ b/extras/k6-operator/configmap.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 data:
   values: |
     k6operatorEnabled: true
+    k6operator:
+      manager:
+        extraArgs:
+          - --metrics-secure=false
 kind: ConfigMap
 metadata:
   name: k6-operator-user-values


### PR DESCRIPTION
This PR disables the flag that's securing the metrics endpoint on k6-operator. Currently alloy is able to discover k6-opeator's servicemonitor but can't retrieve the metrics because the endpoint is protected by a secret. 

As this is for internal purposes only, I think it's easier to just disable this feature rather than updating the servicemonitor to grant it access to the endpoint.
