### PR TITLE
Add missing kustomization.yaml for pro extra

### DIFF
--- a/extras/pro/kustomization.yaml
+++ b/extras/pro/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./namespace.yaml
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./konfiguration.yaml


### PR DESCRIPTION
https://github.com/giantswarm/giantswarm/issues/35670

## Summary

Follow-up to #574. The `extras/pro` directory was missing its `kustomization.yaml`, so kustomize cannot resolve the base when downstream overlays reference `extras/pro?ref=main`. This is what's blocking giantswarm/giantswarm-management-clusters#1976 (`lint` job).

All other `extras/*` bases include this file (see `extras/mcp-runbooks/kustomization.yaml`).
