### PR TITLE
Update giantswarm/install-binary-action to v4.1.0

### DIFF
--- a/.github/workflows/generate_diffs.yaml
+++ b/.github/workflows/generate_diffs.yaml
@@ -30,7 +30,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.check-diff-state.outputs.suspenddiff == 0
     steps:
       - name: install kustomize
-        uses: giantswarm/install-binary-action@e2730babbc89f02ef1559b042d33cbe24f5c3547 # v4.0.2
+        uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
         with:
           binary: kustomize
           download_url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${version}/kustomize_v${version}_linux_amd64.tar.gz"
@@ -39,7 +39,7 @@ jobs:
           version: ${{ env.kustomize_ver }}
       - run: which kustomize
       - name: install dyff
-        uses: giantswarm/install-binary-action@e2730babbc89f02ef1559b042d33cbe24f5c3547 # v4.0.2
+        uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
         with:
           binary: dyff
           download_url: "https://github.com/homeport/dyff/releases/download/v${version}/dyff_${version}_linux_amd64.tar.gz"
@@ -88,7 +88,7 @@ jobs:
           do
             [ -f /tmp/${MC}/old.yaml ] || echo "---" > /tmp/${MC}/old.yaml
             dyff between -i -b -g /tmp/${MC}/old.yaml /tmp/${MC}/new.yaml > /tmp/diff.tmp
-            if ! [[ "$(cat /tmp/diff.tmp)" =~ ^$ ]]
+            if ! [[  "$(cat /tmp/diff.tmp)" =~ ^$ ]]
             then
               echo "==## ${MC} ##==" >> /tmp/diff.results
               cat /tmp/diff.tmp >> /tmp/diff.results


### PR DESCRIPTION
This PR updates `giantswarm/install-binary-action` to v4.1.0, fixing an issue where downloaded binaries fail to execute.

See https://github.com/giantswarm/github/pull/5228 for context.