### PR TITLE
refactor: create new grafana-organizations to take ownership of existing orgs

### DIFF
--- a/bases/collections/shared/base/grafana-organization-giantswarm.yaml
+++ b/bases/collections/shared/base/grafana-organization-giantswarm.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: grafana-organization-giantswarm
+  namespace: giantswarm
+spec:
+  interval: 10m
+  provider: generic
+  ref:
+    semver: x.x.x
+  url: oci://gsoci.azurecr.io/charts/giantswarm/grafana-organization
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana-organization-giantswarm
+  namespace: giantswarm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: grafana-organization-giantswarm
+    namespace: giantswarm
+  install:
+    createNamespace: true
+    remediation:
+      remediateLastFailure: false
+      retries: 10
+  interval: 5m
+  releaseName: grafana-organization-giantswarm
+  storageNamespace: monitoring
+  targetNamespace: monitoring
+  timeout: 10m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 10
+      strategy: rollback
+  valuesFrom:
+  - kind: ConfigMap
+    name: grafana-organization-giantswarm-konfiguration
+    valuesKey: configmap-values.yaml
+  - kind: Secret
+    name: grafana-organization-giantswarm-konfiguration
+    valuesKey: secret-values.yaml

--- a/bases/collections/shared/base/grafana-organization-shared-org.yaml
+++ b/bases/collections/shared/base/grafana-organization-shared-org.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: grafana-organization-shared-org
+  namespace: giantswarm
+spec:
+  interval: 10m
+  provider: generic
+  ref:
+    semver: x.x.x
+  url: oci://gsoci.azurecr.io/charts/giantswarm/grafana-organization
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana-organization-shared-org
+  namespace: giantswarm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: grafana-organization-shared-org
+    namespace: giantswarm
+  install:
+    createNamespace: true
+    remediation:
+      remediateLastFailure: false
+      retries: 10
+  interval: 5m
+  releaseName: grafana-organization-shared-org
+  storageNamespace: monitoring
+  targetNamespace: monitoring
+  timeout: 10m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 10
+      strategy: rollback
+  valuesFrom:
+  - kind: ConfigMap
+    name: grafana-organization-shared-org-konfiguration
+    valuesKey: configmap-values.yaml
+  - kind: Secret
+    name: grafana-organization-shared-org-konfiguration
+    valuesKey: secret-values.yaml

--- a/bases/collections/shared/base/konfiguration.yaml
+++ b/bases/collections/shared/base/konfiguration.yaml
@@ -135,12 +135,24 @@ spec:
             value: grafana
           - name: team
             value: atlas
+      grafana-organization-giantswarm:
+        variables:
+          - name: app
+            value: grafana-organization-giantswarm
+          - name: team
+            value: atlas
       grafana-organization-giantswarm-security-default:
         variables:
           - name: app
             value: grafana-organization-giantswarm-security-default
           - name: team
             value: shield
+      grafana-organization-shared-org:
+        variables:
+          - name: app
+            value: grafana-organization-shared-org
+          - name: team
+            value: atlas
       happa:
         variables:
           - name: app

--- a/bases/collections/shared/base/konfiguration.yaml
+++ b/bases/collections/shared/base/konfiguration.yaml
@@ -95,10 +95,18 @@ spec:
         variables:
           - name: app
             value: grafana
+      grafana-organization-giantswarm:
+        variables:
+          - name: app
+            value: grafana-organization-giantswarm
       grafana-organization-giantswarm-security-default:
         variables:
           - name: app
             value: grafana-organization-giantswarm-security-default
+      grafana-organization-shared-org:
+        variables:
+          - name: app
+            value: grafana-organization-shared-org
       happa:
         variables:
           - name: app

--- a/bases/collections/shared/base/kustomization.yaml
+++ b/bases/collections/shared/base/kustomization.yaml
@@ -19,7 +19,9 @@ resources:
   - fluent-logshipping-app.yaml
   - gateway-api-bundle.yaml
   - grafana.yaml
+  - grafana-organization-giantswarm.yaml
   - grafana-organization-giantswarm-security-default.yaml
+  - grafana-organization-shared-org.yaml
   - happa.yaml
   - ingress-nginx.yaml
   - keda.yaml

--- a/bases/collections/shared/base/kustomization.yaml
+++ b/bases/collections/shared/base/kustomization.yaml
@@ -19,7 +19,9 @@ resources:
   - fluent-logshipping-app.yaml
   - gateway-api-bundle.yaml
   - grafana.yaml
+  - grafana-organization-giantswarm.yaml
   - grafana-organization-giantswarm-security-default.yaml
+  - grafana-organization-shared-org.yaml
   - happa.yaml
   - keda.yaml
   - konfiguration.yaml


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36587

Create apps for our default grafana organizations.
To be merged shortly after https://github.com/giantswarm/shared-configs/pull/643 , so it takes ownership of the orgs that were previously deployed as extraObject in grafana's values.