### PR TITLE
Disable ingress and enable gateway-api by default on zot and backstage

### DIFF
--- a/extras/backstage/main/shared-config.yaml
+++ b/extras/backstage/main/shared-config.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: flux-giantswarm
 data:
   values: |
+    ingress:
+      enabled: false
+    route:
+      enabled: true
+      parentRefs:
+        - name: giantswarm-default
+          namespace: envoy-gateway-system
     sharedConfig: |
       adminGroups:
         - giantswarm-ad:giantswarm-admins

--- a/extras/zot-cache/README.md
+++ b/extras/zot-cache/README.md
@@ -12,29 +12,25 @@ resources:
   - https://github.com/giantswarm/management-cluster-bases/extras/zot-cache?ref=main
 ```
 
-Now, let's say, we need to add `Ingress`
+By default, a `Route` using the `giantswarm-default` gateway in `envoy-gateway-system` is enabled.
 
-1. We need to add another entry to the values configmap (or we can create another configmap/secret)
+### Customizing the Route
+
+To override the route configuration, add an entry to the values configmap:
+
+1. Add another entry to the values configmap (or create another configmap/secret)
 
 ```yaml
-# Here I'm adding an additional entry
 # ./patches/zot-additional-values.yaml
 - op: add
   path: /data/custom-values.yaml
   value: |
-    ingress:
-      enabled: true
-      hosts:
-        - host: zot.golem.gaws.gigantic.io
-          paths:
-            - path: /
-      tls:
-        - secretName: zot-tls
-          hosts:
-            - zot.golem.gaws.gigantic.io
+    route:
+      hostnames:
+        - zot.mycluster.example.gigantic.io
 ```
 
-2. We need to let flux know that these values should be used
+2. Let flux know that these values should be used
 
 ```yaml
 # ./patches/zot-release.yaml
@@ -63,16 +59,6 @@ patches:
       kind: HelmRelease
       name: zot
     path: ./patches/zot-release.yaml
-```
-
-### Private clusters
-
-For private cluster the ingress annotation should use a different cluster issuer.
-
-```yaml
-ingress:
-  annotations:
-    cert-manager.io/cluster-issuer: private-giantswarm
 ```
 
 ## Auth

--- a/extras/zot-cache/values.yaml
+++ b/extras/zot-cache/values.yaml
@@ -4,12 +4,10 @@ service:
 # To enable ingress, please add an additional
 # values file. See the README.md in this directory
 ingress:
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: "1024m"
+  enabled: false
 
 route:
+  enabled: true
   parentRefs:
     - name: giantswarm-default
       namespace: envoy-gateway-system


### PR DESCRIPTION
- **Update zot-cache to disable ingress and enable route by default**
- **Enable route and disable ingress by default for backstage**

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
