### PR TITLE
Add HelmRelease Recovery controller

### DIFF
--- a/bases/collections/shared/base/hr-recovery-controller.yaml
+++ b/bases/collections/shared/base/hr-recovery-controller.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: hr-recovery-controller
+  namespace: giantswarm
+spec:
+  interval: 10m
+  provider: generic
+  ref:
+    semver: x.x.x
+  url: oci://gsoci.azurecr.io/charts/giantswarm/hr-recovery-controller
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hr-recovery-controller
+  namespace: giantswarm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: hr-recovery-controller
+    namespace: giantswarm
+  install:
+    remediation:
+      remediateLastFailure: false
+      retries: 10
+  interval: 5m
+  releaseName: hr-recovery-controller
+  storageNamespace: giantswarm
+  targetNamespace: giantswarm
+  timeout: 5m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 10
+      strategy: rollback


### PR DESCRIPTION
Add the hr-recovery-controller. This controller is required for the migration from App CR to HelmReleases that will be performed when upgrading clusters to v35. It's needed because during the migration, sometimes HelmReleases get stuck while trying to get installed. They fail (i.e. a request to an admission controller fails), but flux can't rollback because it's the first helm release using HelmReleases.

This small controller just suspends and resumes stuck HelmReleases. Once all workload clusters have been migrated to v35, we can remove it.