### PR TITLE
Add extras/agentic-platform base

### DIFF
--- a/extras/agentic-platform/README.md
+++ b/extras/agentic-platform/README.md
@@ -19,19 +19,15 @@ CiliumNetworkPolicies wiring the controller and data plane.
 
 ## Prerequisites
 
-The umbrella does **not** ship the agentgateway CRDs — they're a cluster
-prerequisite:
+As of chart **v0.2.0** the agentgateway CRDs (`AgentgatewayParameters` /
+`Policy` / `Backend`) are bundled as a sub-chart — no separate install needed.
+Muster's CRDs (`MCPServer`, `ServiceClass`, `Workflow`) likewise ship inside the
+umbrella via the muster sub-chart's `templates/crds.yaml`. Remove any standalone
+references to `giantswarm/muster/v*/helm/muster/crds/*.yaml` from the cluster's
+`crds/kustomization.yaml`.
 
-```
-helm install agentgateway-crds \
-  oci://cr.agentgateway.dev/charts/agentgateway-crds --version v1.2.1 \
-  -n muster --create-namespace
-```
-
-Muster's CRDs (`MCPServer`, `ServiceClass`, `Workflow`) ship inside the
-umbrella via the muster sub-chart's `templates/crds.yaml`. Remove any
-standalone references to `giantswarm/muster/v*/helm/muster/crds/*.yaml`
-from the cluster's `crds/kustomization.yaml`.
+The Gateway API v1 CRDs and a Gateway to attach muster's public `HTTPRoute` to
+(e.g. `envoy-gateway-system/giantswarm-default`) remain cluster prerequisites.
 
 ## Configuration
 
@@ -109,7 +105,7 @@ patches:
 ## Dependencies
 
 - dex-app >= 2.1.5 (for muster static client support)
-- agentgateway-crds chart pre-installed
+- Gateway API v1 CRDs + a public Gateway to attach muster's HTTPRoute to
 - shared-configs with an `agentic-platform` app template (renders values
   under the `muster:` umbrella prefix)
 

--- a/extras/agentic-platform/README.md
+++ b/extras/agentic-platform/README.md
@@ -1,0 +1,119 @@
+# Agentic Platform Extras
+
+This directory contains the Flux resources required to deploy the
+`agentic-platform` umbrella chart on a Giant Swarm management cluster.
+
+## Overview
+
+`agentic-platform` is a Helm umbrella that bundles three sub-charts behind a
+single release:
+
+- **muster** — MCP aggregator / OAuth resource server
+- **agentgateway** — MCP data plane (controller + dynamically-rendered
+  data-plane pod via `AgentgatewayParameters`)
+- **valkey** — `giantswarm/valkey-app` for muster's OAuth session storage
+
+It replaces the standalone `extras/muster` base. The umbrella owns the
+`Gateway` (data-plane spawn trigger), `AgentgatewayParameters`, and the
+CiliumNetworkPolicies wiring the controller and data plane.
+
+## Prerequisites
+
+The umbrella does **not** ship the agentgateway CRDs — they're a cluster
+prerequisite:
+
+```
+helm install agentgateway-crds \
+  oci://cr.agentgateway.dev/charts/agentgateway-crds --version v1.2.1 \
+  -n muster --create-namespace
+```
+
+Muster's CRDs (`MCPServer`, `ServiceClass`, `Workflow`) ship inside the
+umbrella via the muster sub-chart's `templates/crds.yaml`. Remove any
+standalone references to `giantswarm/muster/v*/helm/muster/crds/*.yaml`
+from the cluster's `crds/kustomization.yaml`.
+
+## Configuration
+
+Configuration is supplied via two ConfigMaps merged onto the HelmRelease:
+
+1. **shared-configs** rendered into `agentic-platform-konfiguration` by the
+   bundled `Konfiguration` resource. Requires a matching `agentic-platform`
+   template in `giantswarm-config` that renders values under the umbrella's
+   `muster:` subchart prefix (e.g. `muster.muster.oauth.server.baseUrl`).
+2. **per-cluster overrides** via a `agentic-platform-user-values` ConfigMap
+   appended by the consumer kustomization (see usage below).
+
+Required per-cluster fields (template-time fail-guards reject install
+otherwise):
+
+| Field | Notes |
+|---|---|
+| `muster.muster.oauth.server.baseUrl` | Public muster URL (HTTPS) |
+| `muster.muster.oauth.server.dex.issuerUrl` | Dex issuer on this cluster |
+| `muster.muster.oauth.server.dex.clientId` | OAuth client pre-registered in Dex |
+| `muster.muster.oauth.server.existingSecret` | Secret with `dex-client-secret`, `registration-token`, `oauth-encryption-key`, `valkey-password` |
+| `muster.muster.gatewayAPI.httpRoute.parentRefs` | Public Gateway to attach to (e.g. `envoy-gateway-system/giantswarm-default`) |
+| `muster.muster.gatewayAPI.httpRoute.hostnames` | Public hostnames |
+| `valkey.valkey.auth.usersExistingSecret` | Conventionally the same Secret as above (key `valkey-password`) |
+
+## Secrets Required
+
+Before deployment, ensure this Secret exists in the `muster` namespace
+(conventionally a single Secret referenced from both `muster.muster.oauth.server.existingSecret`
+and `valkey.valkey.auth.usersExistingSecret`):
+
+```bash
+kubectl create secret generic agentic-platform-secrets \
+  --namespace muster \
+  --from-literal=dex-client-secret=<dex-client-secret> \
+  --from-literal=registration-token=$(openssl rand -hex 32) \
+  --from-literal=oauth-encryption-key=$(openssl rand -base64 32) \
+  --from-literal=valkey-password=$(openssl rand -base64 32)
+```
+
+## Usage
+
+To deploy on a management cluster, reference this directory from
+`giantswarm-management-clusters`:
+
+```yaml
+# management-clusters/<mc>/extras/agentic-platform/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/giantswarm/management-cluster-bases//extras/agentic-platform?ref=main
+  - agentic-platform-secrets.enc.yaml
+  - ./mcpservers
+  - ./secrets
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: agentic-platform-user-values
+    namespace: flux-giantswarm
+    files:
+      - values=user-values.yaml
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/valuesFrom/-
+        value:
+          kind: ConfigMap
+          name: agentic-platform-user-values
+          valuesKey: values
+    target:
+      kind: HelmRelease
+      name: agentic-platform
+```
+
+## Dependencies
+
+- dex-app >= 2.1.5 (for muster static client support)
+- agentgateway-crds chart pre-installed
+- shared-configs with an `agentic-platform` app template (renders values
+  under the `muster:` umbrella prefix)
+
+## Related
+
+- [agentic-platform chart](https://github.com/giantswarm/agentic-platform)
+- [Muster MC Deployment Concept](https://github.com/giantswarm/muster/blob/main/docs/concepts/mc-deployment.md)

--- a/extras/agentic-platform/README.md
+++ b/extras/agentic-platform/README.md
@@ -61,7 +61,7 @@ and `valkey.valkey.auth.usersExistingSecret`):
 
 ```bash
 kubectl create secret generic agentic-platform-secrets \
-  --namespace muster \
+  --namespace agentic-platform \
   --from-literal=dex-client-secret=<dex-client-secret> \
   --from-literal=registration-token=$(openssl rand -hex 32) \
   --from-literal=oauth-encryption-key=$(openssl rand -base64 32) \

--- a/extras/agentic-platform/helm-release.yaml
+++ b/extras/agentic-platform/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
       retries: 10
       remediateLastFailure: false
   interval: 10m
-  targetNamespace: muster
+  targetNamespace: agentic-platform
   timeout: 10m
   upgrade:
     remediation:

--- a/extras/agentic-platform/helm-release.yaml
+++ b/extras/agentic-platform/helm-release.yaml
@@ -1,0 +1,32 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agentic-platform
+  namespace: flux-giantswarm
+spec:
+  # Explicitly set release name to avoid Flux generating a prefixed name
+  # when targetNamespace differs from HelmRelease namespace
+  releaseName: agentic-platform
+  chartRef:
+    kind: OCIRepository
+    name: agentic-platform
+    namespace: flux-giantswarm
+  install:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  interval: 10m
+  targetNamespace: muster
+  timeout: 10m
+  upgrade:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  valuesFrom:
+    # ConfigMap rendered by Konfiguration from shared-configs template.
+    # NOTE: requires a matching `agentic-platform` template in giantswarm-config
+    # that renders values under the umbrella's `muster:` subchart prefix
+    # (e.g. muster.muster.oauth.server.baseUrl, not oauth.server.baseUrl).
+    - kind: ConfigMap
+      name: agentic-platform-konfiguration
+      valuesKey: configmap-values.yaml

--- a/extras/agentic-platform/konfiguration.yaml
+++ b/extras/agentic-platform/konfiguration.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: konfigure.giantswarm.io/v1alpha1
+kind: Konfiguration
+metadata:
+  name: agentic-platform-konfiguration
+  namespace: flux-giantswarm
+spec:
+  targets:
+    schema:
+      reference:
+        name: management-cluster-configuration
+        namespace: giantswarm
+    defaults:
+      variables:
+        - name: installation
+          value: "${cluster_name}"
+    iterations:
+      agentic-platform:
+        variables:
+          - name: app
+            value: agentic-platform
+  destination:
+    namespace: flux-giantswarm
+    naming:
+      suffix: konfiguration
+  reconciliation:
+    interval: 1m
+    retryInterval: 10s
+    suspend: false
+  sources:
+    flux:
+      gitRepository:
+        name: "giantswarm-config"
+        namespace: "flux-giantswarm"

--- a/extras/agentic-platform/kustomization.yaml
+++ b/extras/agentic-platform/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./namespace.yaml
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./konfiguration.yaml

--- a/extras/agentic-platform/namespace.yaml
+++ b/extras/agentic-platform/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: muster

--- a/extras/agentic-platform/namespace.yaml
+++ b/extras/agentic-platform/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: muster
+  name: agentic-platform

--- a/extras/agentic-platform/oci-repository.yaml
+++ b/extras/agentic-platform/oci-repository.yaml
@@ -7,5 +7,7 @@ spec:
   interval: 10m
   url: oci://gsoci.azurecr.io/charts/giantswarm/agentic-platform
   ref:
-    semver: ">=0.1.0"
+    # Floor at 0.2.0 — the first release that bundles the agentgateway CRDs.
+    # 0.1.0 expects them as a cluster prerequisite and would fail to reconcile.
+    semver: ">=0.2.0"
   provider: generic

--- a/extras/agentic-platform/oci-repository.yaml
+++ b/extras/agentic-platform/oci-repository.yaml
@@ -1,0 +1,11 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: agentic-platform
+  namespace: flux-giantswarm
+spec:
+  interval: 10m
+  url: oci://gsoci.azurecr.io/charts/giantswarm/agentic-platform
+  ref:
+    semver: ">=0.1.0"
+  provider: generic


### PR DESCRIPTION
## Summary

- New Flux base for the [giantswarm/agentic-platform](https://github.com/giantswarm/agentic-platform) umbrella chart (muster + agentgateway + valkey)
- Mirrors `extras/muster`'s layout — namespace, OCIRepository (`semver: ">=0.1.0"`), HelmRelease consuming a Konfiguration-rendered ConfigMap, and an `agentic-platform` Konfiguration
- Bundles three sub-charts into one release: consumers that migrate drop their standalone `muster` + `muster-valkey` HelmReleases

## Prerequisites for consumers

- **agentgateway-crds** chart pre-installed on the cluster:
  ```
  helm install agentgateway-crds \
    oci://cr.agentgateway.dev/charts/agentgateway-crds --version v1.2.1 \
    -n muster --create-namespace
  ```
  Muster CRDs continue to ship inside the umbrella via the muster sub-chart's `templates/crds.yaml` — drop any standalone `muster.giantswarm.io_*.yaml` references from per-cluster `crds/kustomization.yaml`.
- **giantswarm-config** needs a matching `agentic-platform` app template rendering values under the umbrella's `muster:` subchart prefix (e.g. `muster.muster.oauth.server.baseUrl`). Until that lands, consumers can carry the required fields in their per-cluster `user-values.yaml`.
- **agentic-platform 0.1.0** must be published to `gsoci.azurecr.io/charts/giantswarm/agentic-platform`. PR https://github.com/giantswarm/agentic-platform/pull/1 still open.

## First consumer

Graveler — separate PR in `giantswarm-management-clusters` referencing `https://github.com/giantswarm/management-cluster-bases//extras/agentic-platform?ref=main`, includes the SOPS-consolidated `agentic-platform-secrets` Secret (4 keys: dex-client-secret, registration-token, oauth-encryption-key, valkey-password).

## Test plan
- [ ] `kustomize build extras/agentic-platform` succeeds locally
- [ ] After agentic-platform 0.1.0 ships, Flux on graveler reconciles the HelmRelease healthy
- [ ] `agentic-platform-konfiguration` Konfiguration renders a non-empty ConfigMap once the giantswarm-config template lands