### PR TITLE
feat(agentic-platform): add agentic-platform-crds deploy unit

### DIFF
--- a/extras/agentic-platform/README.md
+++ b/extras/agentic-platform/README.md
@@ -19,12 +19,19 @@ CiliumNetworkPolicies wiring the controller and data plane.
 
 ## Prerequisites
 
-As of chart **v0.2.0** the agentgateway CRDs (`AgentgatewayParameters` /
-`Policy` / `Backend`) are bundled as a sub-chart — no separate install needed.
-Muster's CRDs (`MCPServer`, `ServiceClass`, `Workflow`) likewise ship inside the
-umbrella via the muster sub-chart's `templates/crds.yaml`. Remove any standalone
-references to `giantswarm/muster/v*/helm/muster/crds/*.yaml` from the cluster's
-`crds/kustomization.yaml`.
+As of chart **v0.3.0** the agentic-platform umbrella no longer ships any CRDs.
+They have been extracted into a dedicated sibling chart,
+`agentic-platform-crds`, that bundles the agentgateway CRDs
+(`AgentgatewayParameters` / `AgentgatewayPolicy` / `AgentgatewayBackend`) and
+the muster CRDs (`MCPServer`, `Workflow`) as sub-chart dependencies
+(`agentgateway-crds` + `muster-crds`).
+
+This kustomization deploys both releases — `agentic-platform-crds` and
+`agentic-platform` — and the platform's `HelmRelease` declares `dependsOn` the
+crds `HelmRelease`, so Flux will not reconcile the platform release until the
+CRDs release reports Ready. No manual `helm install` for CRDs is required, and
+any standalone references to `giantswarm/muster/v*/helm/muster/crds/*.yaml`
+should be removed from the cluster's `crds/kustomization.yaml`.
 
 The Gateway API v1 CRDs and a Gateway to attach muster's public `HTTPRoute` to
 (e.g. `envoy-gateway-system/giantswarm-default`) remain cluster prerequisites.

--- a/extras/agentic-platform/helm-release-crds.yaml
+++ b/extras/agentic-platform/helm-release-crds.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agentic-platform-crds
+  namespace: flux-giantswarm
+spec:
+  # Explicitly set release name to avoid Flux generating a prefixed name
+  # when targetNamespace differs from HelmRelease namespace
+  releaseName: agentic-platform-crds
+  chartRef:
+    kind: OCIRepository
+    name: agentic-platform-crds
+    namespace: flux-giantswarm
+  install:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  interval: 10m
+  targetNamespace: muster
+  timeout: 10m
+  upgrade:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  # No valuesFrom: agentic-platform-crds is a thin umbrella over the
+  # agentgateway-crds and muster-crds sub-charts and exposes no per-installation
+  # configuration. No Konfiguration is rendered for this release for the same
+  # reason.

--- a/extras/agentic-platform/helm-release-crds.yaml
+++ b/extras/agentic-platform/helm-release-crds.yaml
@@ -16,7 +16,7 @@ spec:
       retries: 10
       remediateLastFailure: false
   interval: 10m
-  targetNamespace: muster
+  targetNamespace: agentic-platform
   timeout: 10m
   upgrade:
     remediation:

--- a/extras/agentic-platform/helm-release.yaml
+++ b/extras/agentic-platform/helm-release.yaml
@@ -7,6 +7,13 @@ spec:
   # Explicitly set release name to avoid Flux generating a prefixed name
   # when targetNamespace differs from HelmRelease namespace
   releaseName: agentic-platform
+  # Cross-resource ordering: the platform chart applies CRs (Gateway,
+  # AgentgatewayParameters, MCPServer, ...) whose CRDs are now shipped by the
+  # sibling agentic-platform-crds release. Block reconciliation until that
+  # HelmRelease is Ready.
+  dependsOn:
+    - name: agentic-platform-crds
+      namespace: flux-giantswarm
   chartRef:
     kind: OCIRepository
     name: agentic-platform

--- a/extras/agentic-platform/kustomization.yaml
+++ b/extras/agentic-platform/kustomization.yaml
@@ -4,5 +4,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./oci-repository.yaml
+  - ./oci-repository-crds.yaml
   - ./helm-release.yaml
+  - ./helm-release-crds.yaml
   - ./konfiguration.yaml

--- a/extras/agentic-platform/oci-repository-crds.yaml
+++ b/extras/agentic-platform/oci-repository-crds.yaml
@@ -1,0 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agentic-platform-crds
+  namespace: flux-giantswarm
+spec:
+  interval: 10m
+  url: oci://gsoci.azurecr.io/charts/giantswarm/agentic-platform-crds
+  ref:
+    # Floor at 0.3.0 — the agentic-platform release that splits CRDs out into
+    # this dedicated sibling chart (agentgateway-crds + muster-crds sub-charts).
+    # Until 0.3.0 ships to the prod catalog this OCIRepository will not resolve
+    # and the platform HelmRelease's dependsOn will hold its reconciliation.
+    semver: ">=0.3.0"
+  provider: generic


### PR DESCRIPTION
## What

Add the Flux deploy unit for the new `agentic-platform-crds` Helm chart alongside the existing `agentic-platform` release in `extras/agentic-platform/`.

`giantswarm/agentic-platform` v0.3.0 splits the CRDs out of the umbrella chart into a dedicated sibling chart `agentic-platform-crds` that bundles `agentgateway-crds` and `muster-crds` as sub-chart dependencies. Operators install the crds release first, then the platform release.

## Changes

- **New** `extras/agentic-platform/oci-repository-crds.yaml` — `OCIRepository` for `oci://gsoci.azurecr.io/charts/giantswarm/agentic-platform-crds`, `semver: ">=0.3.0"`, `interval: 10m`, `provider: generic`. The explicit `>=0.3.0` floor is so the dep does not resolve until the new chart actually lands in the catalog.
- **New** `extras/agentic-platform/helm-release-crds.yaml` — `HelmRelease` named `agentic-platform-crds` in `flux-giantswarm`, `releaseName: agentic-platform-crds`, `targetNamespace: muster`, referencing the new `OCIRepository`. Remediation policy mirrored from the platform `HelmRelease` (`retries: 10`, `remediateLastFailure: false` on both install and upgrade), `interval: 10m`, `timeout: 10m`. No `valuesFrom` and no `Konfiguration` — the crds chart is a thin umbrella with no per-installation configuration.
- **Edit** `extras/agentic-platform/helm-release.yaml` — add `spec.dependsOn` referencing `agentic-platform-crds` in `flux-giantswarm` so Flux does not reconcile the platform release until the crds release reports Ready.
- **Edit** `extras/agentic-platform/kustomization.yaml` — register the two new files in `resources`.
- **Edit** `extras/agentic-platform/README.md` — rewrite the Prerequisites section. Drop the now-incorrect claim that muster's CRDs ship "inside the umbrella via the muster sub-chart's `templates/crds.yaml`". Note that the `agentic-platform-crds` chart is deployed alongside via this same kustomization, with ordering enforced by the platform's `dependsOn`.

## Verification

`kubectl kustomize extras/agentic-platform` rendered locally:

- `HelmRelease` count: **2** (agentic-platform, agentic-platform-crds)
- `OCIRepository` count: **2** (agentic-platform, agentic-platform-crds)
- `agentic-platform` `.spec.dependsOn`: `[{name: agentic-platform-crds, namespace: flux-giantswarm}]`
- `agentic-platform-crds` `.spec.ref.semver`: `>=0.3.0`

YAML validates via `yq` on all changed files. `pre-commit` is not installed on this host; the only configured hook is `gitleaks-docker` and the changes contain no secrets.

## Merge gate

**Do NOT merge until `agentic-platform` v0.3.0 is released to the prod catalog (`gsoci.azurecr.io/charts/giantswarm/agentic-platform-crds`).**

If merged before v0.3.0 ships:

- The new `agentic-platform-crds` `OCIRepository` cannot resolve (no chart matches `>=0.3.0`).
- The `agentic-platform-crds` `HelmRelease` stays NotReady.
- The platform `HelmRelease` `dependsOn` will hold reconciliation, so the platform release stops rolling forward to new versions.
- The currently-running 0.2.0 release keeps serving, but no new applies happen until 0.3.0 lands and the floor resolves.

## Related

- `giantswarm/agentic-platform#12` — chart split (merged, awaiting v0.3.0 tag)
- `giantswarm/muster#750` — muster CRDs extracted into `muster-crds` (released as `muster-crds 0.1.213`, consumed as a sub-chart by `agentic-platform-crds`)
