### PR TITLE
chore(agentic-platform): pin OCIRepository to 1.0.0 for the ingress.mode cutover

### DIFF
--- a/extras/agentic-platform/oci-repository.yaml
+++ b/extras/agentic-platform/oci-repository.yaml
@@ -7,7 +7,12 @@ spec:
   interval: 10m
   url: oci://gsoci.azurecr.io/charts/giantswarm/agentic-platform
   ref:
-    # Floor at 0.2.0 — the first release that bundles the agentgateway CRDs.
-    # 0.1.0 expects them as a cluster prerequisite and would fail to reconcile.
-    semver: ">=0.2.0"
+    # Pinned to 1.0.0 — the release that introduces the breaking `ingress.mode`
+    # topology refactor (removes gateway.enabled/httpRoute/backendTrafficPolicy;
+    # the umbrella now owns muster's public route). The matching values
+    # migration lives in shared-configs (default/apps/agentic-platform). Pinning
+    # (rather than a floating range) makes the cutover deliberate: this pin and
+    # the shared-configs migration must land together, else the chart and its
+    # rendered values disagree. Bump deliberately on future upgrades.
+    semver: "1.0.0"
   provider: generic


### PR DESCRIPTION
## What

Pin the `agentic-platform` `OCIRepository` from the floating `semver: ">=0.2.0"` to an exact `1.0.0`.

## Why

agentic-platform `1.0.0` (giantswarm/agentic-platform#27) is a **breaking** release: it collapses the request topology into a single `ingress.mode` selector and removes `gateway.enabled` / `gateway.httpRoute.*` / `gateway.backendTrafficPolicy.*`; the umbrella now owns muster's public route. The matching rendered values live in `shared-configs` (`default/apps/agentic-platform`).

With a floating range, the breaking chart would be auto-pulled the moment it's published — before its values migration — and the HelmRelease would fail schema validation (removed keys) or render a duplicate muster route. Pinning makes the upgrade **deliberate**: this pin and the shared-configs values migration must land together.

## Coordinated cutover (do not merge in isolation)

1. Merge + release giantswarm/agentic-platform#27 → publishes chart `1.0.0`.
2. Merge **this** PR **together with** the shared-configs values migration so the chart and its rendered values change in the same reconcile window.

Affects every MC consuming this base (currently the agentic-platform-enabled management clusters). All currently run the agentgateway-in-front topology, which maps to `ingress.mode: agentgateway-muster`.