### PR TITLE
fix(mcp-pagerduty): point OCIRepository at correct chart name

### DIFF
--- a/extras/mcp-pagerduty/oci-repository.yaml
+++ b/extras/mcp-pagerduty/oci-repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-giantswarm
 spec:
   interval: 10m
-  url: oci://gsoci.azurecr.io/charts/giantswarm/mcp-pagerduty
+  url: oci://gsoci.azurecr.io/charts/giantswarm/pagerduty-mcp-server
   ref:
     # Auto-update: deploy latest version automatically
     semver: ">=0.0.0"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35670

OCIRepository for `mcp-pagerduty` was pointing at `charts/giantswarm/mcp-pagerduty`, but the chart is actually published as `pagerduty-mcp-server`. The fork [`giantswarm/pagerduty-mcp-server#14`](https://github.com/giantswarm/pagerduty-mcp-server/pull/14) renamed the chart back from `mcp-pagerduty` to satisfy the architect orb (which expects the chart name to match the repo name).
