### PR TITLE
fix(falco): raise HelmRelease timeout to 30m

### DIFF
--- a/bases/collections/shared/base/falco.yaml
+++ b/bases/collections/shared/base/falco.yaml
@@ -29,7 +29,7 @@ spec:
   releaseName: falco
   storageNamespace: giantswarm
   targetNamespace: giantswarm
-  timeout: 10m
+  timeout: 30m
   upgrade:
     remediation:
       remediateLastFailure: true


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36817

- The default `spec.timeout: 10m` is too short for the falco DaemonSet to finish a sequential rollout on larger MCs (chart-default `maxUnavailable: 1`, ~45-75 s per pod for the new 0.12.0 image + plugin pulls + startupProbe).
- Verified live on gazelle (18 nodes): the 0.11.2 → 0.12.0 upgrade that was previously failing with `context deadline exceeded` after 10 m completed in ~23 min with the timeout raised to 30 m. See giantswarm/giantswarm#36817 for the postmortem and verification details.