### PR TITLE
Increase falco HelmRelease update timeout to 45m

### DIFF
--- a/bases/collections/shared/base/falco.yaml
+++ b/bases/collections/shared/base/falco.yaml
@@ -29,7 +29,7 @@ spec:
   releaseName: falco
   storageNamespace: giantswarm
   targetNamespace: giantswarm
-  timeout: 10m
+  timeout: 45m
   upgrade:
     remediation:
       remediateLastFailure: true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/36817