### PR TITLE
chore: update releases SDK to v0.13.0

### DIFF
--- a/bases/crds/giantswarm/stages/testing/releases/kustomization.yaml
+++ b/bases/crds/giantswarm/stages/testing/releases/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.10.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
+  - https://raw.githubusercontent.com/giantswarm/releases/sdk/v0.13.0/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml


### PR DESCRIPTION
This is required to add support for AKS releases
