### PR TITLE
Bump dex-app 2.2.1 -> 2.2.2

### DIFF
--- a/bases/collections/shared/base/dex-app.yaml
+++ b/bases/collections/shared/base/dex-app.yaml
@@ -20,4 +20,4 @@ spec:
     inCluster: true
   name: dex-app
   namespace: giantswarm
-  version: 2.2.1
+  version: 2.2.2


### PR DESCRIPTION
## Summary

Bump the shared-collection `dex-app` App CR from `2.2.1` to `2.2.2` for all management clusters.

dex-app `2.2.2` ships `dex` `v2.43.1-gs4` (giantswarm/dex#74, giantswarm/dex-app#469/#470): the OIDC connector no longer drops its `rootCAs`-aware HTTP client when `providerDiscoveryOverrides` is set. This fixes RFC 8693 token-exchange subject-token verification (JWKS fetch) for connectors whose issuer is served by a privately-trusted CA — e.g. the reverse SPIFFE `dex-<mc>` tunnel used by private/sovereign devportal clusters, which currently fail cross-cluster cluster-token minting with `x509: certificate signed by unknown authority`. Clusters with publicly-trusted issuers are unaffected (pure bugfix).

## Rollout note

This is a fleet-wide bump (shared collection → every MC via the per-provider collections). The fix is a strict superset bugfix of 2.2.1. Please review for rollout pacing; the immediate motivation is unblocking the private/sovereign devportal clusters (leopard/tamarin) cluster-token path.

## Validation plan

- After merge + Flux reconcile, confirm dex-app `2.2.2` on a representative MC and re-run the RFC 8693 token-exchange repro on the SPIFFE-tunnel clusters (expect `access_denied` for a dummy token / success for a real session token, instead of `x509: unknown authority`).

Made with [Cursor](https://cursor.com)