### PR TITLE
agentic-platform: deploy the 1.5.x meta-package (app-of-apps)

### DIFF
--- a/extras/agentic-platform/README.md
+++ b/extras/agentic-platform/README.md
@@ -1,37 +1,51 @@
 # Agentic Platform Extras
 
 This directory contains the Flux resources required to deploy the
-`agentic-platform` umbrella chart on a Giant Swarm management cluster.
+`agentic-platform` meta-package on a Giant Swarm management cluster.
 
 ## Overview
 
-`agentic-platform` is a Helm umbrella that bundles three sub-charts behind a
-single release:
+As of chart **v1.5.x** `agentic-platform` is a **meta-package (app-of-apps)**:
+it no longer bundles sub-charts, but renders each component as its own Flux
+`OCIRepository` + `HelmRelease` (version ranges resolved at reconcile time, so
+component releases roll forward with no PR). Components include muster (MCP
+aggregator / OAuth resource server), valkey (OAuth session storage),
+agentgateway (MCP data plane), kagent, klaus-gateway, agent-sandbox, and the
+`agentic-platform-connectivity` chart that owns the wiring (public `HTTPRoute`,
+`Gateway`, `AgentgatewayParameters`, CiliumNetworkPolicies).
 
-- **muster** — MCP aggregator / OAuth resource server
-- **agentgateway** — MCP data plane (controller + dynamically-rendered
-  data-plane pod via `AgentgatewayParameters`)
-- **valkey** — `giantswarm/valkey-app` for muster's OAuth session storage
+On Giant Swarm clusters the meta-package's `HelmRelease` sets:
 
-It replaces the standalone `extras/muster` base. The umbrella owns the
-`Gateway` (data-plane spawn trigger), `AgentgatewayParameters`, and the
-CiliumNetworkPolicies wiring the controller and data plane.
+```yaml
+spec:
+  values:
+    gitops:
+      namespace: flux-giantswarm      # render the child Flux CRs here — exempt
+      targetNamespace: agentic-platform  #   from flux-multi-tenancy; workloads here
+    components:
+      agentic-platform-crds:
+        enabled: false                # delegated to the sibling crds HelmRelease
+```
+
+The child `HelmRelease`s are created in `flux-giantswarm` (the
+flux-multi-tenancy Kyverno policy rejects HelmReleases lacking
+`serviceAccountName` outside `flux-giantswarm`/`giantswarm`/`monitoring`) and
+install their workloads into `agentic-platform`. Each child `dependsOn` the
+`agentic-platform-crds` release.
 
 ## Prerequisites
 
-As of chart **v0.3.0** the agentic-platform umbrella no longer ships any CRDs.
-They have been extracted into a dedicated sibling chart,
-`agentic-platform-crds`, that bundles the agentgateway CRDs
-(`AgentgatewayParameters` / `AgentgatewayPolicy` / `AgentgatewayBackend`) and
-the muster CRDs (`MCPServer`, `Workflow`) as sub-chart dependencies
-(`agentgateway-crds` + `muster-crds`).
-
-This kustomization deploys both releases — `agentic-platform-crds` and
-`agentic-platform` — and the platform's `HelmRelease` declares `dependsOn` the
-crds `HelmRelease`, so Flux will not reconcile the platform release until the
-CRDs release reports Ready. No manual `helm install` for CRDs is required, and
-any standalone references to `giantswarm/muster/v*/helm/muster/crds/*.yaml`
-should be removed from the cluster's `crds/kustomization.yaml`.
+CRDs (agentgateway `AgentgatewayParameters` / `AgentgatewayPolicy` /
+`AgentgatewayBackend`, muster `MCPServer` / `Workflow`) ship via the dedicated
+`agentic-platform-crds` chart. This kustomization deploys it as its own
+`HelmRelease` (`helm-release-crds.yaml`), kept separate from the meta-package so
+a single release object owns those cluster-scoped CRDs. The meta-package
+therefore sets `components.agentic-platform-crds.enabled: false` and its child
+releases `dependsOn` the crds `HelmRelease` — Flux will not reconcile a
+component until the CRDs release reports Ready. No manual `helm install` for
+CRDs is required, and any standalone references to
+`giantswarm/muster/v*/helm/muster/crds/*.yaml` should be removed from the
+cluster's `crds/kustomization.yaml`.
 
 The Gateway API v1 CRDs and a Gateway to attach muster's public `HTTPRoute` to
 (e.g. `envoy-gateway-system/giantswarm-default`) remain cluster prerequisites.

--- a/extras/agentic-platform/helm-release.yaml
+++ b/extras/agentic-platform/helm-release.yaml
@@ -29,6 +29,21 @@ spec:
     remediation:
       retries: 10
       remediateLastFailure: false
+  # GitOps topology for the meta-package (chart >=1.5.1). The chart renders each
+  # component as its own OCIRepository + HelmRelease. Create those Flux objects in
+  # flux-giantswarm (exempt from the flux-multi-tenancy Kyverno policy, which would
+  # otherwise reject child HelmReleases for missing serviceAccountName) and route
+  # the workloads to the agentic-platform namespace. crds is delegated to the
+  # sibling agentic-platform-crds HelmRelease below (helm-release-crds.yaml), so
+  # the meta-package must not render its own crds release (avoids dual ownership);
+  # the other child releases still dependsOn it by name in flux-giantswarm.
+  values:
+    gitops:
+      namespace: flux-giantswarm
+      targetNamespace: agentic-platform
+    components:
+      agentic-platform-crds:
+        enabled: false
   valuesFrom:
     # ConfigMap rendered by Konfiguration from shared-configs template.
     # NOTE: requires a matching `agentic-platform` template in giantswarm-config

--- a/extras/agentic-platform/oci-repository.yaml
+++ b/extras/agentic-platform/oci-repository.yaml
@@ -7,7 +7,10 @@ spec:
   interval: 10m
   url: oci://gsoci.azurecr.io/charts/giantswarm/agentic-platform
   ref:
-    # Floor at 0.2.0 — the first release that bundles the agentgateway CRDs.
-    # 0.1.0 expects them as a cluster prerequisite and would fail to reconcile.
-    semver: ">=0.2.0"
+    # Floor at 1.5.1 — the meta-package (app-of-apps) era. From 1.5.0 the chart
+    # renders each component as its own Flux OCIRepository + HelmRelease instead
+    # of bundling subcharts; 1.5.1 adds the gitops.namespace/targetNamespace knobs
+    # this base relies on to satisfy the flux-multi-tenancy admission policy.
+    # Earlier (umbrella) releases ignore those knobs and would be rejected.
+    semver: ">=1.5.1"
   provider: generic


### PR DESCRIPTION
## Problem

`agentic-platform` became a **meta-package (app-of-apps)** in chart `1.5.x`: it renders each component as its own Flux `OCIRepository` + `HelmRelease` instead of bundling sub-charts. The existing `OCIRepository` range (`>=0.2.0`) already auto-pulled `1.5.0` onto every consuming MC (graveler, gazelle, glean), and it **failed to reconcile on all three** — the rendered child HelmReleases landed in the `agentic-platform` namespace without a `serviceAccountName` and were denied by the `flux-multi-tenancy` Kyverno policy:

```
HelmRelease/agentic-platform/agentgateway was blocked ... flux-multi-tenancy:
  serviceAccountNameMustBeSet
```

No outage occurred (the failed upgrade never tore down the running 1.4.x workloads), but Flux is stuck.

## Change

Wire the meta-package for GS clusters (chart `1.5.1` adds the required knobs):

- Floor the `agentic-platform` `OCIRepository` at `>=1.5.1` (earlier umbrella releases ignore the new knobs).
- Set inline on the `HelmRelease`:
  - `gitops.namespace: flux-giantswarm` — render the child Flux CRs in a namespace **exempt** from `flux-multi-tenancy` (`flux-giantswarm`/`giantswarm`/`monitoring`).
  - `gitops.targetNamespace: agentic-platform` — install the workloads in the platform namespace.
  - `components.agentic-platform-crds.enabled: false` — delegate CRDs to the existing standalone `agentic-platform-crds` HelmRelease (avoids two managers owning the same release object); child releases still `dependsOn` it by name in `flux-giantswarm`.
- The standalone `agentic-platform-crds` HelmRelease + its OCIRepository are kept unchanged.

This mirrors the base's existing working pattern (HelmRelease in `flux-giantswarm`, `targetNamespace: agentic-platform`).

## Impact / rollout

Shared base — reconciles to **graveler, gazelle, and glean** (all currently broken on 1.5.0, so this fixes all three). The umbrella→meta transition recreates muster/valkey/agentgateway as separate child releases, so expect a brief restart of those workloads (incl. gazelle's muster MCP gateway) as Flux converges.

## Validation

- `kustomize build` of the base renders cleanly (namespace, meta HR, crds HR, konfiguration, both OCIRepositories).
- Chart side validated in agentic-platform#154 (`make verify-meta` asserts the namespace routing + crds delegation); charts published at `1.5.1`.

Made with [Cursor](https://cursor.com)