### PR TITLE
muster: cap standalone base OCIRepository ranges at 0.x

### DIFF
--- a/extras/muster/oci-repository.yaml
+++ b/extras/muster/oci-repository.yaml
@@ -7,6 +7,8 @@ spec:
   interval: 10m
   url: oci://gsoci.azurecr.io/charts/giantswarm/muster
   ref:
-    # Auto-update: deploy latest version automatically
-    semver: ">=0.0.0"
+    # Auto-update within the current 0.x line. An unbounded ">=0.0.0" would jump
+    # to a future 1.0 major automatically; cap at 0.x to match the agentic-platform
+    # meta-package's muster component range and avoid surprise major upgrades.
+    semver: "0.x"
   provider: generic

--- a/extras/muster/valkey-oci-repository.yaml
+++ b/extras/muster/valkey-oci-repository.yaml
@@ -7,5 +7,7 @@ spec:
   interval: 10m
   url: oci://gsoci.azurecr.io/charts/giantswarm/valkey
   ref:
-    semver: ">=0.0.0"
+    # Cap at 0.x rather than an unbounded ">=0.0.0" to avoid a surprise jump to a
+    # future valkey 1.0 major. Matches the agentic-platform meta-package range.
+    semver: "0.x"
   provider: generic


### PR DESCRIPTION
## Problem

The standalone `extras/muster` base pinned both the muster and muster-valkey `OCIRepository` sources at `semver: ">=0.0.0"`. That range auto-upgrades across **major** versions, so a future muster/valkey `1.0` would roll out automatically without review.

This also caused live drift on the Giant Swarm MCs (gazelle, graveler): after they migrated muster to the `agentic-platform` meta-package (#627), the meta-package's `0.x` range could not take effect because stale server-side-apply field ownership from this base's `>=0.0.0` was frozen on the cluster OCIRepository. (The clusters have been reconciled to `0.x`; this PR fixes the base so the same drift can't recur on customer MCs still consuming it.)

## Fix

Cap both sources at `0.x`, matching the agentic-platform meta-package's muster/valkey component ranges. Still auto-updates within the current major line; no longer jumps majors silently.

## Scope

This base is still consumed by `deploy-mcp-kubernetes` for customer muster onboarding, so it is intentionally **not** deleted — only its ranges are bounded.

## Test plan

- [x] Bounded ranges resolve to the current releases (muster `0.10.0`, valkey `0.1.2`)

Made with [Cursor](https://cursor.com)