### PR TITLE
muster: app-owned CRDs via install/upgrade crds CreateReplace

### DIFF
--- a/extras/muster/helm-release.yaml
+++ b/extras/muster/helm-release.yaml
@@ -12,6 +12,11 @@ spec:
     name: muster
     namespace: flux-giantswarm
   install:
+    # App-owned CRDs: the muster app chart ships its MCPServer / Workflow CRDs in
+    # its own crds/ dir. CreateReplace makes Flux apply and upgrade them atomically
+    # with the app on every release (Helm never upgrades crds/-dir CRDs on its own),
+    # so the CRDs always match the running muster version on this standalone path.
+    crds: CreateReplace
     remediation:
       retries: 10
       remediateLastFailure: false
@@ -19,6 +24,7 @@ spec:
   targetNamespace: muster
   timeout: 10m
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 10
       remediateLastFailure: false


### PR DESCRIPTION
## Summary

- Adds `install.crds: CreateReplace` and `upgrade.crds: CreateReplace` to the standalone muster `HelmRelease` (`extras/muster/helm-release.yaml`).

## Why

The muster app chart now ships its `MCPServer` / `Workflow` CRDs in its own `crds/` directory (app-owned CRDs). `CreateReplace` makes Flux apply and upgrade them atomically with the app on every release (Helm never upgrades `crds/`-dir CRDs on its own), so the CRDs always match the running muster version on the customer standalone path — mirroring the meta-package change in giantswarm/agentic-platform#161.

## Test plan

- [ ] CI green.
- [ ] Customer standalone muster picks up CRDs via the app release (no separate muster-crds install needed).

Companion: giantswarm/agentic-platform#161

Made with [Cursor](https://cursor.com)