### PR TITLE
agentic-platform: stamp owning-team label on umbrella Flux resources

### DIFF
--- a/extras/agentic-platform/helm-release-crds.yaml
+++ b/extras/agentic-platform/helm-release-crds.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: agentic-platform-crds
   namespace: flux-giantswarm
+  labels:
+    # Owning team for Flux-failure alert routing and Backstage catalog ownership.
+    application.giantswarm.io/team: bumblebee
 spec:
   # Explicitly set release name to avoid Flux generating a prefixed name
   # when targetNamespace differs from HelmRelease namespace

--- a/extras/agentic-platform/helm-release.yaml
+++ b/extras/agentic-platform/helm-release.yaml
@@ -3,6 +3,11 @@ kind: HelmRelease
 metadata:
   name: agentic-platform
   namespace: flux-giantswarm
+  labels:
+    # Owning team for Flux-failure alert routing and Backstage catalog ownership.
+    # The umbrella HelmRelease is created by this base (not rendered by the chart),
+    # so the chart's labels.common helper never stamps it — set it explicitly here.
+    application.giantswarm.io/team: bumblebee
 spec:
   # Explicitly set release name to avoid Flux generating a prefixed name
   # when targetNamespace differs from HelmRelease namespace

--- a/extras/agentic-platform/oci-repository-crds.yaml
+++ b/extras/agentic-platform/oci-repository-crds.yaml
@@ -3,6 +3,9 @@ kind: OCIRepository
 metadata:
   name: agentic-platform-crds
   namespace: flux-giantswarm
+  labels:
+    # Owning team for Flux-failure alert routing and Backstage catalog ownership.
+    application.giantswarm.io/team: bumblebee
 spec:
   interval: 10m
   url: oci://gsoci.azurecr.io/charts/giantswarm/agentic-platform-crds

--- a/extras/agentic-platform/oci-repository.yaml
+++ b/extras/agentic-platform/oci-repository.yaml
@@ -3,6 +3,9 @@ kind: OCIRepository
 metadata:
   name: agentic-platform
   namespace: flux-giantswarm
+  labels:
+    # Owning team for Flux-failure alert routing and Backstage catalog ownership.
+    application.giantswarm.io/team: bumblebee
 spec:
   interval: 10m
   url: oci://gsoci.azurecr.io/charts/giantswarm/agentic-platform

--- a/extras/mcp-runbooks/helm-release.yaml
+++ b/extras/mcp-runbooks/helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: mcp-runbooks
   namespace: flux-giantswarm
+  labels:
+    # Owning team for Flux-failure alert routing and Backstage catalog ownership.
+    application.giantswarm.io/team: bumblebee
 spec:
   # Explicitly set release name to avoid Flux generating a prefixed name
   # when targetNamespace differs from HelmRelease namespace

--- a/extras/mcp-runbooks/oci-repository.yaml
+++ b/extras/mcp-runbooks/oci-repository.yaml
@@ -3,6 +3,9 @@ kind: OCIRepository
 metadata:
   name: mcp-runbooks
   namespace: flux-giantswarm
+  labels:
+    # Owning team for Flux-failure alert routing and Backstage catalog ownership.
+    application.giantswarm.io/team: bumblebee
 spec:
   interval: 10m
   url: oci://gsociprivate.azurecr.io/charts/giantswarm/mcp-runbooks


### PR DESCRIPTION
## Problem

Flux-failure alerts for the agentic-platform stack on management clusters route to **Honey Badger** instead of **Bumblebee** (the owning team).

The child Flux resources rendered by the `agentic-platform` chart (`agentgateway`, `agentic-platform-connectivity`, `muster`, `kagent`, `klaus-gateway`) carry `application.giantswarm.io/team: bumblebee` because the chart's `labels.common` helper stamps it. But the **umbrella** resources — `agentic-platform`, `agentic-platform-crds`, and `mcp-runbooks` — are defined in this base and created by the `flux-extras` Kustomization, not rendered by the chart, so the helper never runs on them. Their team label resolves to `<none>`, so Flux-failure alerts fall back to the gitops owner (Honey Badger).

## Change

Add `application.giantswarm.io/team: bumblebee` as a **label** on the umbrella `HelmRelease` and `OCIRepository` definitions:

- `extras/agentic-platform/helm-release.yaml`
- `extras/agentic-platform/helm-release-crds.yaml`
- `extras/agentic-platform/oci-repository.yaml`
- `extras/agentic-platform/oci-repository-crds.yaml`
- `extras/mcp-runbooks/helm-release.yaml`
- `extras/mcp-runbooks/oci-repository.yaml`

## Acceptance criteria

- [x] Umbrella agentic-platform Flux resources carry the `application.giantswarm.io/team: bumblebee` label (applies to all MCs consuming this base).
- [ ] A Flux failure on any agentic-platform component pages Bumblebee, not Honey Badger (verify after rollout).
- [ ] Backstage catalog shows correct Bumblebee ownership (verify with Atlas/Honey Badger that alert routing reads the Flux-resource label).

Fixes giantswarm/giantswarm#36951

Made with [Cursor](https://cursor.com)