### PR TITLE
Migrate HelmRepository chart sources to OCIRepository

### DIFF
--- a/bases/catalogs/giantswarm/appcatalog-cluster-test.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-cluster-test.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-cluster-test
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-cluster.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-cluster.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-cluster
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-control-plane-catalog.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-control-plane-catalog.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-control-plane-catalog
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-control-plane-test-catalog.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-control-plane-test-catalog.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-control-plane-test-catalog
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-default-test.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-default-test.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-default-test
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-default.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-default.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-default
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-giantswarm-operations-platform-test.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-giantswarm-operations-platform-test.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-giantswarm-operations-platform-test
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-giantswarm-operations-platform.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-giantswarm-operations-platform.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-giantswarm-operations-platform
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-giantswarm-playground-test.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-giantswarm-playground-test.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-giantswarm-playground-test
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-giantswarm-playground.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-giantswarm-playground.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-giantswarm-playground
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-giantswarm-test.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-giantswarm-test.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-giantswarm-test
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-giantswarm.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-giantswarm.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-giantswarm
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-releases-test.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-releases-test.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-releases-test
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/appcatalog-releases.yaml
+++ b/bases/catalogs/giantswarm/appcatalog-releases.yaml
@@ -4,14 +4,10 @@ metadata:
   name: appcatalog-releases
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: appcatalog
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-control-plane-catalog
-        namespace: flux-giantswarm
-      version: 1.0.0
+  chartRef:
+    kind: OCIRepository
+    name: appcatalog
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 20

--- a/bases/catalogs/giantswarm/kustomization.yaml
+++ b/bases/catalogs/giantswarm/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - ocirepository-appcatalog.yaml
   - appcatalog-cluster.yaml
   - appcatalog-cluster-test.yaml
   - appcatalog-control-plane-catalog.yaml

--- a/bases/catalogs/giantswarm/ocirepository-appcatalog.yaml
+++ b/bases/catalogs/giantswarm/ocirepository-appcatalog.yaml
@@ -1,0 +1,11 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: appcatalog
+  namespace: flux-giantswarm
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "1.0.1"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/appcatalog

--- a/bases/flux-operator/helmrelease.yaml
+++ b/bases/flux-operator/helmrelease.yaml
@@ -1,18 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+  namespace: flux-giantswarm
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "0.3.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/flux-operator
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: flux-operator
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: flux-operator
-      interval: 5m
-      reconcileStrategy: ChartVersion
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-      version: 0.3.0
+  chartRef:
+    kind: OCIRepository
+    name: flux-operator
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 3

--- a/bases/provider/aws-china/flux-v2/kustomization.yaml
+++ b/bases/provider/aws-china/flux-v2/kustomization.yaml
@@ -6,6 +6,8 @@ patches:
   - path: patch-source-controller.yaml
   - path: patch-control-plane-catalog-helmrepository.yaml
   - path: patch-giantswarm-catalog-helmrepository.yaml
+  - path: patch-control-plane-catalog-ocirepositories.yaml
+  - path: patch-giantswarm-catalog-ocirepositories.yaml
 images:
   - name: giantswarm/fluxcd-helm-controller
     newName: giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/fluxcd-helm-controller

--- a/bases/provider/aws-china/flux-v2/patch-control-plane-catalog-ocirepositories.yaml
+++ b/bases/provider/aws-china/flux-v2/patch-control-plane-catalog-ocirepositories.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: appcatalog
+  namespace: flux-giantswarm
+spec:
+  timeout: 3m0s

--- a/bases/provider/aws-china/flux-v2/patch-giantswarm-catalog-ocirepositories.yaml
+++ b/bases/provider/aws-china/flux-v2/patch-giantswarm-catalog-ocirepositories.yaml
@@ -1,0 +1,23 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+  namespace: flux-giantswarm
+spec:
+  timeout: 3m0s
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: external-secrets
+  namespace: flux-giantswarm
+spec:
+  timeout: 3m0s
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: zot
+  namespace: flux-giantswarm
+spec:
+  timeout: 3m0s

--- a/bases/provider/eks/helmrelease/cert-manager/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/cert-manager/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cert-manager-app
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "4.0.1"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/cert-manager-app
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: cert-manager-app
-      version: 3.5.3
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: cert-manager-app
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/cert-manager/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/cert-manager/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cert-manager-app
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "3.11.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/cert-manager-app
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: cert-manager-app
-      version: 3.5.3
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: cert-manager-app
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/cert-manager/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/cert-manager/helmrelease.yaml
@@ -1,15 +1,3 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: cert-manager-app
-  namespace: org-sample
-spec:
-  interval: 5m
-  provider: generic
-  ref:
-    tag: "4.0.1"
-  url: oci://gsoci.azurecr.io/charts/giantswarm/cert-manager-app
----
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -22,10 +10,14 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chartRef:
-    kind: OCIRepository
-    name: cert-manager-app
-    namespace: org-sample
+  chart:
+    spec:
+      chart: cert-manager-app
+      version: 3.5.3
+      sourceRef:
+        kind: HelmRepository
+        name: giantswarm-catalog
+        namespace: default
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/example-helmrelease-app/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/example-helmrelease-app/helmrelease.yaml
@@ -10,12 +10,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: podinfo
-      sourceRef:
-        kind: HelmRepository
-        name: podinfo
+  chartRef:
+    kind: OCIRepository
+    name: podinfo
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/example-helmrelease-app/repository.yaml
+++ b/bases/provider/eks/helmrelease/example-helmrelease-app/repository.yaml
@@ -1,8 +1,11 @@
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
+kind: OCIRepository
 metadata:
   name: podinfo
   namespace: org-sample
 spec:
   interval: 5m
-  url: https://stefanprodan.github.io/podinfo
+  provider: generic
+  ref:
+    semver: ">=6.0.0"
+  url: oci://ghcr.io/stefanprodan/charts/podinfo

--- a/bases/provider/eks/helmrelease/external-dns/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/external-dns/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: external-dns-app
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "3.5.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/external-dns-app
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: external-dns-app
-      version: 2.42.0
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: external-dns-app
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/fluent-logshipping-app/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/fluent-logshipping-app/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: fluent-logshipping-app
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "5.6.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/fluent-logshipping-app
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: fluent-logshipping-app
-      version: 3.0.2
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: fluent-logshipping-app
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/grafana/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/grafana/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: grafana
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "2.38.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/grafana
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: grafana
-      version: 2.5.0
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: grafana
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/hello-world/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/hello-world/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hello-world
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "3.0.2"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/hello-world
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: hello-world
-      version: '2.2.0'
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: hello-world
+    namespace: org-sample
   interval: 30m
   install:
     createNamespace: true

--- a/bases/provider/eks/helmrelease/loki/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/loki/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: loki
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "0.45.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/loki
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: loki
-      version: 0.14.0
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: loki
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/metrics-server/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/metrics-server/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: metrics-server-app
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "2.8.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/metrics-server-app
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: metrics-server-app
-      version: 2.4.0
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-default-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: metrics-server-app
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/observability-bundle/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/observability-bundle/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: prometheus-operator-crd
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "21.0.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/prometheus-operator-crd
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: prometheus-operator-crd
-      version: 6.1.0
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-default-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: prometheus-operator-crd
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/bases/provider/eks/helmrelease/vertical-pod-autoscaler/helmrelease.yaml
+++ b/bases/provider/eks/helmrelease/vertical-pod-autoscaler/helmrelease.yaml
@@ -1,3 +1,15 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vertical-pod-autoscaler-app
+  namespace: org-sample
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "6.1.2"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/vertical-pod-autoscaler-app
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -10,14 +22,10 @@ spec:
   kubeConfig:
     secretRef:
       name: sample-customer-kubeconfig
-  chart:
-    spec:
-      chart: vertical-pod-autoscaler-app
-      version: 4.2.0
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-default-catalog
-        namespace: default
+  chartRef:
+    kind: OCIRepository
+    name: vertical-pod-autoscaler-app
+    namespace: org-sample
   interval: 50m
   install:
     remediation:

--- a/extras/external-secrets/helmrelease-external-secrets.yaml
+++ b/extras/external-secrets/helmrelease-external-secrets.yaml
@@ -1,17 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: external-secrets
+  namespace: flux-giantswarm
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "2.4.1"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/external-secrets
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-secrets
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: external-secrets
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: flux-giantswarm
-      version: 2.4.1
+  chartRef:
+    kind: OCIRepository
+    name: external-secrets
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 10

--- a/extras/zot-cache/helm-release.yaml
+++ b/extras/zot-cache/helm-release.yaml
@@ -1,18 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: zot
+  namespace: flux-giantswarm
+spec:
+  interval: 5m
+  provider: generic
+  ref:
+    tag: "2.8.0"
+  url: oci://gsoci.azurecr.io/charts/giantswarm/zot
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: zot
   namespace: flux-giantswarm
 spec:
-  chart:
-    spec:
-      chart: zot
-      reconcileStrategy: ChartVersion
-      sourceRef:
-        kind: HelmRepository
-        name: giantswarm-catalog
-        namespace: flux-giantswarm
-      version: 2.8.0
+  chartRef:
+    kind: OCIRepository
+    name: zot
+    namespace: flux-giantswarm
   install:
     remediation:
       retries: 10


### PR DESCRIPTION
## Human gist

- replaces HelmRepo with OCIRepo with the same app version where possible
- not possible for EKS - not being used currently (AFAIK) so we don't care about the bumps
- catalog HRs are still migrated to not polute the metric, but they going to be killed anyway (still used now)

## Summary

- Replaces HTTP `HelmRepository` chart sources with `OCIRepository` for all charts available at `gsoci.azurecr.io/charts/giantswarm`, following the existing pattern already used in `bases/collections/vsphere` and `capz`
- Each migrated `HelmRelease` now uses `spec.chartRef` instead of `spec.chart.spec.sourceRef`
- One shared `OCIRepository` resource created for `appcatalog` (used by 14 HelmReleases)
- AWS China: new strategic merge patch files added to apply `spec.timeout: 3m0s` to the new OCIRepository resources (equivalent to existing HelmRepository timeout patches)

**Migrated sources:**
| Chart | Old version | New version | Notes |
|---|---|---|---|
| flux-operator | 0.3.0 | 0.3.0 | exact match |
| external-secrets | 2.4.1 | 2.4.1 | exact match |
| zot | 2.8.0 | 2.8.0 | exact match |
| appcatalog | 1.0.0 | 1.0.1 | patch bump (1.0.0 not in OCI) |
| cert-manager-app | 3.5.3 | 3.11.0 | lowest available in OCI (3.5.3 not published) |
| fluent-logshipping-app | 3.0.2 | 5.6.0 | EKS example |
| grafana | 2.5.0 | 2.38.0 | EKS example |
| loki | 0.14.0 | 0.45.0 | EKS example |
| hello-world | 2.2.0 | 3.0.2 | EKS example |
| external-dns-app | 2.42.0 | 3.5.0 | EKS example |
| vertical-pod-autoscaler-app | 4.2.0 | 6.1.2 | EKS example |
| metrics-server-app | 2.4.0 | 2.8.0 | EKS example |
| prometheus-operator-crd | 6.1.0 | 21.0.0 | EKS example |
| podinfo | unversioned | >=6.0.0 | example, migrated to ghcr.io |

**Still on HelmRepository** (not yet in OCI registry — tracked separately):
gitops-server, promtail, prometheus-operator-app, prometheus-agent, caicloud-event-exporter-app, container-agent (intentional, third-party)

## Test plan

- [ ] Verify OCIRepository resources become Ready=True on a test cluster: flux get sources oci -n flux-giantswarm
- [ ] Verify HelmReleases remain Ready=True after source switch: flux get helmreleases -A
- [ ] For AWS China clusters: confirm timeout patches apply to OCIRepository resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)