### PR TITLE
fix: use conventional commits in silences-report-expire action

### DIFF
--- a/.github/actions/silences-report-expired/silences-report-expired.sh
+++ b/.github/actions/silences-report-expired/silences-report-expired.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 YQ="bin/yq"
 KUSTOMIZATION_FILENAME="kustomization.yaml"
 
-COMMIT_MESSAGE_PREFIX="remove expired silence - "
+COMMIT_MESSAGE_PREFIX="chore(silences): remove expired silence - "
 PULL_REQUEST_BODY_EXPIRED="This pull request was automatically created using the $(basename "$0") script.
 
 If you are assigned for review, this means you created a silence which is **now expired** based on the \`valid-until\` annotation, and has **been removed from AlertManager**.


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
