### PR TITLE
Add kagent-flux ServiceAccount for Flux to deploy charts into the kagent namespace

### DIFF
--- a/extras/agentic-platform/README.md
+++ b/extras/agentic-platform/README.md
@@ -128,6 +128,38 @@ patches:
 - shared-configs with an `agentic-platform` app template (renders values
   under the `muster:` umbrella prefix)
 
+## Deploying additional charts into `kagent`
+
+This base also provisions a `kagent-flux` ServiceAccount in the `kagent`
+namespace (`service-account.yaml`), bound to the built-in `cluster-admin`
+`ClusterRole` via a namespace-scoped `RoleBinding` — i.e. full control of all
+resources **within `kagent`** only.
+
+The `kagent` namespace itself is **not** created here — it is owned by the
+`agentic-platform-connectivity` component (Helm). Flux applies the SA/RoleBinding
+once that namespace exists, retrying on its interval until then.
+
+Use it to deploy additional agent-platform charts as `HelmRelease`s living in
+the `kagent` namespace. Unlike the umbrella (which lives in the
+policy-exempt `flux-giantswarm`), a `HelmRelease` in `kagent` is subject to the
+`flux-multi-tenancy` Kyverno policy, so it **must** set `serviceAccountName` and
+target its own namespace:
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: <chart>
+  namespace: kagent
+spec:
+  serviceAccountName: kagent-flux   # required by flux-multi-tenancy Kyverno policy
+  targetNamespace: kagent           # must be local (targetNamespaceMustBeLocal rule)
+  ...
+```
+
+Because the binding is namespace-scoped, such charts can only create namespaced
+resources in `kagent`; cluster-scoped resources (CRDs, ClusterRoles) are denied.
+
 ## Related
 
 - [agentic-platform chart](https://github.com/giantswarm/agentic-platform)

--- a/extras/agentic-platform/kustomization.yaml
+++ b/extras/agentic-platform/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
   - ./konfiguration.yaml
+  - ./service-account.yaml

--- a/extras/agentic-platform/service-account.yaml
+++ b/extras/agentic-platform/service-account.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kagent-flux
+  namespace: kagent
+  labels:
+    application.giantswarm.io/team: bumblebee
+---
+# Namespace-scoped admin: a RoleBinding to the built-in cluster-admin ClusterRole
+# grants full control of ALL resources (including custom resources) within the
+# kagent namespace only. Used by Flux (spec.serviceAccountName: kagent-flux) to
+# deploy additional agent-platform HelmReleases into this namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kagent-flux
+  namespace: kagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kagent-flux
+    namespace: kagent


### PR DESCRIPTION
## What

Adds a `kagent-flux` ServiceAccount in the `kagent` namespace to the `agentic-platform` extras base, bound to the built-in `cluster-admin` ClusterRole via a namespace-scoped `RoleBinding` (full control of all resources **within `kagent`** only).

## Why

We want Flux to deploy **additional agent-platform charts** as `HelmRelease`s living in the `kagent` namespace. The `flux-multi-tenancy` Kyverno `ClusterPolicy` enforces that any `HelmRelease`/`Kustomization` outside the exempt `flux-giantswarm`/`giantswarm`/`monitoring` namespaces sets `spec.serviceAccountName` and targets its own local namespace. Flux impersonates that SA when reconciling, so it needs RBAC to install the charts' resources and manage Helm's release Secrets in `kagent`.

A future HelmRelease references it like:

```yaml
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: <chart>
  namespace: kagent
spec:
  serviceAccountName: kagent-flux
  targetNamespace: kagent
```

## Notes

- The `kagent` namespace is **not** created here — it is owned by the `agentic-platform-connectivity` component (Helm). Flux applies the SA/RoleBinding once that namespace exists, retrying on its interval until then.
- The binding is namespace-scoped, so charts using this SA can only create namespaced resources in `kagent`; cluster-scoped resources (CRDs, ClusterRoles) are denied. This is fine given agentic-platform CRDs are app-owned by the umbrella release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)