### PR TITLE
Bump dex-app 2.2.2 -> 2.2.3

### DIFF
--- a/bases/collections/shared/base/dex-app.yaml
+++ b/bases/collections/shared/base/dex-app.yaml
@@ -20,4 +20,4 @@ spec:
     inCluster: true
   name: dex-app
   namespace: giantswarm
-  version: 2.2.2
+  version: 2.2.3


### PR DESCRIPTION
## What

Bump `dex-app` `2.2.2` → `2.2.3` in the shared collection base.

## Why

Rolls out the GitHub connector refresh-token fix to management clusters. dex-app `2.2.3` ships dex `v2.43.2` (cherry-pick of upstream [dexidp/dex#4845](https://github.com/dexidp/dex/pull/4845)), which fixes forced re-login after ~8h for GitHub App-backed connectors: GitHub App user-to-server tokens expire after 8 hours, and the old connector could not renew the upstream token on dex refresh, so sessions died at login+8h. The connector now persists GitHub's refresh token + expiry and renews the upstream access token on `Refresh()`.

## Provenance

- dex `v2.43.2` — giantswarm/dex#78 (image `gsoci.azurecr.io/giantswarm/dex:v2.43.2`)
- dex-app `2.2.3` — giantswarm/dex-app#476 (chart in `control-plane-catalog`, index.yaml lists `2.2.3`)

## Rollout note

Existing GitHub-backed sessions only benefit after each user logs in once post-rollout — older `connectorData` has no upstream refresh token stored. After that, sessions are bounded by dex policy (720h) rather than dying at 8h.
