### PR TITLE
fix: Add policy exception for contrib crossplane-provider-aws deployment

### DIFF
--- a/extras/crossplane/providers/upbound/aws/polex.yaml
+++ b/extras/crossplane/providers/upbound/aws/polex.yaml
@@ -23,6 +23,7 @@ spec:
         names:
         - upbound-provider*
         - crossplane-contrib-provider*
+        - crossplane-provider-aws
         - function*
         namespaces:
         - crossplane


### PR DESCRIPTION
Towards https://github.com/giantswarm/adidas/issues/1469. Without this, the default Crossplane-generated manifest isn't accepted by our default Kyverno policies.