### PR TITLE
fix: Remove dangling function-kustomization.yaml reference in extras/crossplane

### DIFF
--- a/extras/crossplane/kustomization.yaml
+++ b/extras/crossplane/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
   - providers-kustomization.yaml
   - claims-kustomization.yaml
   - composition-kustomization.yaml
-  - function-kustomization.yaml


### PR DESCRIPTION
## What

Follow-up to #665. That PR removed `extras/crossplane/function-kustomization.yaml` but left the `- function-kustomization.yaml` entry in `extras/crossplane/kustomization.yaml`, so the kustomization now references a file that no longer exists.

## Why

`kustomize build` of `extras/crossplane` at `?ref=main` fails for every management-clusters repo that includes it:

```
Error: accumulating resources: ... 'function-kustomization.yaml':
evalsymlink failure on '.../extras/crossplane/function-kustomization.yaml':
lstat .../extras/crossplane/function-kustomization.yaml: no such file or directory
```

This is fleet-wide, it breaks CI (`make build-<mc>`) in every `*-management-clusters` repo consuming `extras/crossplane`.

## Change

Remove the dangling `- function-kustomization.yaml` line. Safe per #665's own rationale: `providers-kustomization.yaml` recursively includes the functions directory, so the entry was redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)