### PR TITLE
Backstage: add per-instance agent avatar CSP source slot

### DIFF
--- a/extras/backstage/main/shared-config.yaml
+++ b/extras/backstage/main/shared-config.yaml
@@ -12,6 +12,16 @@ data:
       parentRefs:
         - name: giantswarm-default
           namespace: envoy-gateway-system
+    backstage:
+      # Default agent-avatar CSP source (see sharedConfig.csp.imgSrc). Overridden
+      # per instance to the installation's own `https://avatars.<baseDomain>`
+      # (space-separated for the fleet-wide Dev Portal). Defaulting to `'self'`
+      # keeps img-src valid for instances that don't set it. NOTE: extraEnvVars is
+      # a list, so an instance that sets its own extraEnvVars must re-list this
+      # entry (or set BACKSTAGE_AVATARS_IMG_SRC to its avatars host).
+      extraEnvVars:
+        - name: BACKSTAGE_AVATARS_IMG_SRC
+          value: "'self'"
     sharedConfig: |
       adminGroups:
         - giantswarm-ad:giantswarm-admins
@@ -86,6 +96,15 @@ data:
           - 'https://pkg.go.dev'
           - 'https://s.giantswarm.io'
           - 'https://user-images.githubusercontent.com'
+          # Agent avatar icons (agent-platform plugin) are loaded in the browser
+          # from the self-hosted DiceBear endpoint(s) at `avatars.<baseDomain>`.
+          # Each instance sets the BACKSTAGE_AVATARS_IMG_SRC env var to the
+          # host(s) it needs (space-separated for multiple): a per-installation
+          # Backstage sets its own `https://avatars.<baseDomain>`; the fleet-wide
+          # Dev Portal sets the set of installations whose agents it lists. It
+          # defaults to `'self'` (a harmless duplicate) so instances that don't
+          # set it keep a valid img-src -- see backstage.extraEnvVars below.
+          - '$${BACKSTAGE_AVATARS_IMG_SRC}'
         scriptSrc:
           - "'self'"
           - "'unsafe-eval'"


### PR DESCRIPTION
The agent-platform plugin (backstage#1971) renders each agent's avatar as an `<img>` loaded directly from the self-hosted DiceBear endpoint at `avatars.<baseDomain>`. Because `img-src` is a strict host allowlist, those hosts must be allowlisted or the icons silently degrade to initials.

Backstage **replaces** config arrays across files and `$include` can't append, so a per-instance config can't add a single item to the shared `img-src`. Instead this adds one **substitution slot** to the shared list:

```yaml
imgSrc:
  # … shared third-party hosts …
  - '$${BACKSTAGE_AVATARS_IMG_SRC}'
```

Each Backstage instance then sets `BACKSTAGE_AVATARS_IMG_SRC` via `backstage.extraEnvVars` in its own config:

- **A per-installation Backstage** sets its own single `https://avatars.<baseDomain>`.
- **The fleet-wide Dev Portal** (`devportal.giantswarm.io`, the only instance that enables `page:agent-platform` today) sets a **space-separated** set of the installations whose agents it lists — Helmet space-joins the array into the CSP directive, so one entry can carry several hosts.

It **defaults to `'self'`** (a harmless duplicate already on the list) so instances that don't set it keep a valid `img-src`. Note `extraEnvVars` is a list, so an instance that sets its own `extraEnvVars` for other reasons must re-list this entry — called out in a comment.

Follow-up (separate PR, giantswarm-management-clusters): set `BACKSTAGE_AVATARS_IMG_SRC` on the gazelle Dev Portal to `https://avatars.gazelle.awsprod.gigantic.io https://avatars.graveler.gaws2.gigantic.io`.

Refs giantswarm/giantswarm#37211