### PR TITLE
cfg: enable kyverno rules for cluster chart config map

### DIFF
--- a/bases/collections/shared/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/shared/stages/stable-testing/kustomization.yaml
@@ -9,5 +9,10 @@ patches:
       name: konfigure-operator
       namespace: giantswarm
     path: semver-konfigure-operator.yaml
+  - target:
+      kind: OCIRepository
+      name: kyverno-policies-ux
+      namespace: giantswarm
+    path: semver-kyverno-policies-ux.yaml
 resources:
   - ../../base

--- a/bases/collections/shared/stages/stable-testing/semver-kyverno-policies-ux.yaml
+++ b/bases/collections/shared/stages/stable-testing/semver-kyverno-policies-ux.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/ref/semver
+  value: ">=0.0.0-0"
+- op: add
+  path: /spec/ref/semverFilter
+  value: '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'


### PR DESCRIPTION
This enables mutating App and HR CRs, that deploy cluster charts, to have the cluster config map injected.