### PR TITLE
Hardcode Crossplane Azure provider service account names instead of using placeholders

### DIFF
--- a/extras/crossplane/providers/upbound/azure/service-account.yaml
+++ b/extras/crossplane/providers/upbound/azure/service-account.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: replaced by kustomization
+  name: upbound-provider-azure
   namespace: crossplane
   annotations: {}
   labels:
@@ -24,7 +24,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: replaced by kustomization
+  name: upbound-provider-azure
   labels:
     psp-binding: "true"
 roleRef:
@@ -33,7 +33,7 @@ roleRef:
   name: crossplane-use-psp
 subjects:
   - kind: ServiceAccount
-    name: replaced by kustomization
+    name: upbound-provider-azure
     namespace: crossplane
 ---
 apiVersion: v1

--- a/extras/crossplane/providers/upbound/azure/setting-up-workloadidentity.md
+++ b/extras/crossplane/providers/upbound/azure/setting-up-workloadidentity.md
@@ -1,3 +1,0 @@
-# Setting up workload identity
-
-- [TBD]


### PR DESCRIPTION
Same as https://github.com/giantswarm/management-cluster-bases/pull/387, but for Azure. The kustomization failed to render due to the unnecessary placeholders.