### PR TITLE
fix: add hr-recovery-controller to kustomization.yaml file

### DIFF
--- a/bases/collections/shared/base/kustomization.yaml
+++ b/bases/collections/shared/base/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - grafana-organization-giantswarm-security-default.yaml
   - grafana-organization-shared-org.yaml
   - happa.yaml
+  - hr-recovery-controller.yaml
   - keda.yaml
   - konfiguration.yaml
   - konfigure-operator.yaml


### PR DESCRIPTION
I added the `HelmRelease` and `OCIRepository` [in this PR](https://github.com/giantswarm/management-cluster-bases/pull/596) but I forgot to add them to the kustomization file.