### PR TITLE
ci: build every collection stage on PRs

### DIFF
--- a/.github/workflows/build-collections.yaml
+++ b/.github/workflows/build-collections.yaml
@@ -1,0 +1,46 @@
+name: Build collections
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+env:
+  # Keep in sync with the kustomize version shipped by kustomize-controller.
+  kustomize_ver: "5.6.0"
+
+jobs:
+  build-collections:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install kustomize
+        uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
+        with:
+          binary: kustomize
+          download_url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${version}/kustomize_v${version}_linux_amd64.tar.gz"
+          smoke_test: "${binary} version"
+          tarball_binary_path: "${binary}"
+          version: ${{ env.kustomize_ver }}
+
+      # Deliberately no --load-restrictor: management clusters consume these
+      # collections as remote bases, and kustomize enforces
+      # LoadRestrictionsRootOnly inside the git clone it creates for them, no
+      # matter what --load-restrictor says. Building with the default here is
+      # what makes this job catch what kustomize-controller would reject.
+      - name: Build every collection stage
+        run: |
+          rc=0
+          for dir in bases/collections/*/stages/*/; do
+            if kustomize build "${dir}" > /dev/null; then
+              echo "ok    ${dir}"
+            else
+              echo "FAIL  ${dir}"
+              rc=1
+            fi
+          done
+          exit "${rc}"

--- a/.github/workflows/build-collections.yaml
+++ b/.github/workflows/build-collections.yaml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Keep in sync with the kustomize version shipped by kustomize-controller.
-  kustomize_ver: "5.6.0"
-
 jobs:
   build-collections:
     runs-on: ubuntu-latest
@@ -18,29 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install kustomize
-        uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
-        with:
-          binary: kustomize
-          download_url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${version}/kustomize_v${version}_linux_amd64.tar.gz"
-          smoke_test: "${binary} version"
-          tarball_binary_path: "${binary}"
-          version: ${{ env.kustomize_ver }}
-
-      # Deliberately no --load-restrictor: management clusters consume these
-      # collections as remote bases, and kustomize enforces
-      # LoadRestrictionsRootOnly inside the git clone it creates for them, no
-      # matter what --load-restrictor says. Building with the default here is
-      # what makes this job catch what kustomize-controller would reject.
+      # The target downloads its own pinned kustomize, so this runs exactly like
+      # `make build-collections` on a laptop.
       - name: Build every collection stage
-        run: |
-          rc=0
-          for dir in bases/collections/*/stages/*/; do
-            if kustomize build "${dir}" > /dev/null; then
-              echo "ok    ${dir}"
-            else
-              echo "FAIL  ${dir}"
-              rc=1
-            fi
-          done
-          exit "${rc}"
+        run: make build-collections

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,7 +1,8 @@
 # Check https://github.com/fluxcd/flux2/blob/main/.github/runners/prereq.sh if
-# you're updating kustomize versions.
+# you're updating kustomize versions. Keep this matching the kustomize version
+# shipped by kustomize-controller, so a local build behaves like a cluster one.
 KUSTOMIZE := ./bin/kustomize
-KUSTOMIZE_VERSION ?= v4.5.7
+KUSTOMIZE_VERSION ?= v5.6.0
 
 YQ := ./bin/yq
 YQ_VERSION := 4.31.2
@@ -16,6 +17,25 @@ build-catalogs-with-defaults: $(KUSTOMIZE) ## Build Giant Swarm catalogs with de
 	mkdir -p output
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone bases/catalogs -o output/catalogs-with-defaults.yaml
 
+
+# Deliberately no --load-restrictor: management clusters consume these
+# collections as remote bases, and kustomize enforces LoadRestrictionsRootOnly
+# inside the git clone it creates for them, no matter what --load-restrictor
+# says. Building with the default here is what catches what kustomize-controller
+# would reject.
+.PHONY: build-collections
+build-collections: $(KUSTOMIZE) ## Build every collection stage the way kustomize-controller would
+	@echo "====> $@"
+	@rc=0; \
+	for dir in bases/collections/*/stages/*/; do \
+		if $(KUSTOMIZE) build "$$dir" >/dev/null; then \
+			echo "ok    $$dir"; \
+		else \
+			echo "FAIL  $$dir"; \
+			rc=1; \
+		fi; \
+	done; \
+	exit $$rc
 
 $(KUSTOMIZE): ## Download kustomize locally if necessary.
 	@echo "====> $@"


### PR DESCRIPTION
#656 broke graveler and had to be reverted in #679, and no CI job in this repo could have caught it. This adds one.

## Why nothing caught it

Two independent gaps:

1. **No job builds `bases/collections/**`.** `lint.yaml`, `generate_diffs.yaml` and `delete_diffs.yaml` are `workflow_call` templates that MC gitops repos (wacker, fleetio, …) call against their own `management-clusters/` directory — that directory does not exist here, so they never run in this repo. The `Makefile` targets only build `bases/catalogs` and `bases/crds/*`.
2. **Every existing build relaxes the load restrictor.** `Makefile.custom.mk` and the workflows all pass `--load-restrictor=LoadRestrictionsNone`. Kustomize enforces `LoadRestrictionsRootOnly` inside the git clone it creates for a remote base *regardless of that flag*, so a relaxed local build can pass while kustomize-controller rejects the very same collection on a cluster.

## What this does

A `Build collections` job on every PR that runs, with the **default** load restrictor:

```console
for dir in bases/collections/*/stages/*/; do kustomize build "${dir}"; done
```

44 targets, a few seconds. kustomize is pinned to 5.6.0, matching the version used by `generate_diffs.yaml` and shipped by kustomize-controller.

## Evidence it works

Same loop run against three trees:

| tree | result |
|---|---|
| `main` | exit 0 |
| the reverted #656 branch (`291856f`) | **exit 1, 18 stages failing** |
| #680 (the component-based re-land) | exit 0 |

## Not covered here

MC repos consume plenty more of this repo as remote bases — `extras/**` (~170 references), `bases/provider/**`, `bases/crds/*/stages/*`, `bases/flux-*` — and those are subject to the same root-only rule. Extending the loop to them needs a per-directory check first, since some of those directories are `kind: Component` fragments that are not meant to build standalone (`bases/flux-app-v2/common` for instance). Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)