### PR TITLE
fix: remove konfigure-operator kyverno mutating policy

### DIFF
--- a/bases/extras-package/kustomization.yaml
+++ b/bases/extras-package/kustomization.yaml
@@ -1,4 +1,3 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-  - ../../extras/konfigure-operator-policy
+resources: []


### PR DESCRIPTION
The CRD version v1 for it and required Kyverno features wont be available on clusters until v35. It was only accidentally available so far.
