### PR TITLE
fix(ci): only delete a diff comment when one was found

### DIFF
--- a/.github/workflows/delete_diffs.yaml
+++ b/.github/workflows/delete_diffs.yaml
@@ -16,11 +16,15 @@ jobs:
         continue-on-error: true
         id: fc
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          # this workflow is triggered by `issue_comment`, where
+          # `github.event.pull_request` is not set
+          issue-number: ${{ github.event.issue.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Rendered manifest diff
       - name: Delete diff comments
         uses: jungwinter/comment@fda92dbcb5e7e79cccd55ecb107a8a3d7802a469 # v1.1.0
+        # nothing to delete if no diff comment was found
+        if: steps.fc.outputs.comment-id != ''
         continue-on-error: true
         with:
           type: delete

--- a/.github/workflows/generate_diffs.yaml
+++ b/.github/workflows/generate_diffs.yaml
@@ -113,6 +113,8 @@ jobs:
           body-includes: Rendered manifest diff
       - name: Delete old comment
         uses: winterjung/comment@fda92dbcb5e7e79cccd55ecb107a8a3d7802a469 # v1.1.0
+        # nothing to delete if no previous comment was found
+        if: steps.fc.outputs.comment-id != ''
         continue-on-error: true
         with:
           type: delete


### PR DESCRIPTION
## What

Gate the diff-comment delete steps on `find-comment` actually having found a comment.

## Why

Spotted in [this run](https://github.com/giantswarm/giantswarm-management-clusters/actions/runs/30621210459/job/91125966814?pr=2259): `Delete old comment` reports `##[error]cannot delete comment`.

`peter-evans/find-comment` emits an **empty** `comment-id` when nothing matches, and we piped that straight into `winterjung/comment`, which errors when asked to delete nothing. The job log confirms it — the action was invoked with `"delete" "***" "" "" ""`. `continue-on-error: true` kept the job green, so the only symptom was a misleading red annotation on every PR's *first* diff run.

Worth being explicit about what this does **not** fix: in that run, `Create or update validation comment` was skipped by its own `if: steps.diff.outputs.stdout != ''`, **not** by the delete failure (the delete step's conclusion was `success` thanks to `continue-on-error`). PR #2259 only touched `management-clusters/gazelle/extras/**`, which isn't in that cluster's `kustomization.yaml` `resources:` — it ships via the `flux-extras` Flux Kustomization — so the render was unchanged and posting no comment was correct.

## Also in here

`delete_diffs.yaml` is triggered by `issue_comment`, where `github.event.pull_request` is not set, so `issue-number` resolved to empty and `/deletediffs` could never find a comment to delete. Switched to `github.event.issue.number`. Without this, the new guard would just turn that job into a silent no-op instead of a noisy one.

## Testing

`yamllint` clean. Both workflows are `workflow_call`-only and consumers pin `@main`, so this needs a merge before it can be exercised end-to-end: on a PR that produces a real diff, the first run should show `Delete old comment` as skipped with no annotation, and the second run should actually delete and re-post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)