### PR TITLE
feat(flux): Increase concurrency to 32.

### DIFF
--- a/bases/flux-app-v2/common/kustomization.yaml
+++ b/bases/flux-app-v2/common/kustomization.yaml
@@ -57,7 +57,7 @@ patches:
           - --log-level=info
           - --log-encoding=json
           - --enable-leader-election
-          - --concurrent=12
+          - --concurrent=32
   - target:
       kind: Deployment
       name: image-automation-controller


### PR DESCRIPTION
With the change from App CRs & Chart CRs to HelmRelease CRs, the amount of HelmRelease CRs on a management cluster increases drastically.

When spinning up multiple clusters at the same time (happens when running CAPA Standard, CAPA Upgrade and CAPA Cilium ENI Mode in parallel for example as they all end up creating workload clusters on the same management cluster), I found myself in a situation where the Helm Controller tried to install some HelmRelease CRs which never succeeded because one of their dependencies didn't get picked up at the same time.

I know, this sounds weird, but currently we configure dependencies in a way the HelmRelease CR at least does not fail right from the beginning because some CRD is missing. Runtime dependencies can be hard to determine, especially when teams do not have the complete picture and only test their changes on existing clusters.

One case could be Metrics Server being installed and having all its CRDs installed already, but Cilium or some other component removing a taint from nodes not being around, yet. If there are too many clusters, this also means more HelmRelease CRs to be reconciled at the same time and if you're unlucky, it does not pick the required ones and therefore gets blocked on installing others.

As said: The true solution to that would be getting dependencies right. I am working on that in the context of CAPI v35.0.0, but I think increasing the concurrency here makes it a more resilient solution overall.