### PR TITLE
Add alloy-logexporter to collections, inert by default

### DIFF
--- a/bases/collections/shared/base/alloy-logexporter.yaml
+++ b/bases/collections/shared/base/alloy-logexporter.yaml
@@ -1,0 +1,90 @@
+---
+# alloy-logexporter — the audit/Teleport log export pipeline (giantswarm/giantswarm#37251).
+#
+# Deployed to every management cluster but INERT: the defaults ConfigMap below turns
+# the release into a no-op that renders zero objects until the feature is switched
+# on. `alloy.enabled: false` gates the whole upstream chart via `condition:
+# alloy.enabled` in alloy-app's Chart.yaml.
+#
+# observability-operator turns it on by creating the `alloy-logexporter-config`
+# ConfigMap, which carries `alloy.enabled: true`, the deployment shape and the Alloy
+# config. That ConfigMap is optional here so this stays valid before it exists.
+#
+# Note the chart is `alloy` while the release is `alloy-logexporter` — the same
+# one-chart-many-names arrangement observability-bundle uses for
+# alloy-logs/alloy-metrics/alloy-events.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: alloy-logexporter
+  namespace: giantswarm
+spec:
+  interval: 10m
+  provider: generic
+  ref:
+    semver: x.x.x
+  url: oci://gsoci.azurecr.io/charts/giantswarm/alloy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-logexporter-defaults
+  namespace: giantswarm
+data:
+  values: |
+    # Off unless observability-operator says otherwise.
+    #
+    # All three keys are required to render nothing. Disabling the dependency alone
+    # is NOT enough: Helm drops a subchart entirely when its condition is false,
+    # including its _helpers.tpl, and alloy-app's own templates call `alloy.labels`
+    # / `alloy.chart` from the subchart. With only `alloy.enabled: false` the
+    # release fails to template with:
+    #   no template "alloy.chart" associated with template "gotpl"
+    # so alloy-app's own templates have to be switched off as well. `flavor: none`
+    # matches neither the cilium nor the kubernetes branch, so no policy renders.
+    alloy:
+      enabled: false
+    networkPolicy:
+      flavor: none
+    kyvernoPolicyExceptions:
+      enabled: false
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy-logexporter
+  namespace: giantswarm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: alloy-logexporter
+    namespace: giantswarm
+  install:
+    createNamespace: true
+    remediation:
+      remediateLastFailure: false
+      retries: 10
+  interval: 5m
+  releaseName: alloy-logexporter
+  storageNamespace: alloy-logexporter
+  targetNamespace: alloy-logexporter
+  timeout: 10m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 10
+      strategy: rollback
+  # DO NOT add `spec.values` here. Flux merges valuesFrom entries in order and then
+  # lets inline values override all of them, so anything set inline — including
+  # `alloy.enabled` — would permanently override observability-operator and the
+  # feature could never be enabled. Order below matters for the same reason: the
+  # operator's ConfigMap is last so that it wins.
+  valuesFrom:
+  - kind: ConfigMap
+    name: alloy-logexporter-defaults
+    valuesKey: values
+  - kind: ConfigMap
+    name: alloy-logexporter-config
+    valuesKey: values
+    # Absent until observability-operator enables the feature on this installation.
+    optional: true

--- a/bases/collections/shared/base/alloy-logexporter.yaml
+++ b/bases/collections/shared/base/alloy-logexporter.yaml
@@ -1,18 +1,13 @@
 ---
 # alloy-logexporter — the audit/Teleport log export pipeline (giantswarm/giantswarm#37251).
 #
-# Deployed to every management cluster but INERT: the defaults ConfigMap below turns
-# the release into a no-op that renders zero objects until the feature is switched
-# on. `alloy.enabled: false` gates the whole upstream chart via `condition:
-# alloy.enabled` in alloy-app's Chart.yaml.
+# Deployed to every management cluster but disabled by default: the defaults
+# ConfigMap below turns the release into a no-op that renders zero objects until the
+# feature is switched on.
 #
 # observability-operator turns it on by creating the `alloy-logexporter-config`
 # ConfigMap, which carries `alloy.enabled: true`, the deployment shape and the Alloy
 # config. That ConfigMap is optional here so this stays valid before it exists.
-#
-# Note the chart is `alloy` while the release is `alloy-logexporter` — the same
-# one-chart-many-names arrangement observability-bundle uses for
-# alloy-logs/alloy-metrics/alloy-events.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -32,21 +27,9 @@ metadata:
   namespace: giantswarm
 data:
   values: |
-    # Off unless observability-operator says otherwise.
-    #
-    # All three keys are required to render nothing. Disabling the dependency alone
-    # is NOT enough: Helm drops a subchart entirely when its condition is false,
-    # including its _helpers.tpl, and alloy-app's own templates call `alloy.labels`
-    # / `alloy.chart` from the subchart. With only `alloy.enabled: false` the
-    # release fails to template with:
-    #   no template "alloy.chart" associated with template "gotpl"
-    # so alloy-app's own templates have to be switched off as well. `flavor: none`
-    # matches neither the cilium nor the kubernetes branch, so no policy renders.
+    # Off unless observability-operator says otherwise. Gates the whole chart via
+    # `condition: alloy.enabled` on the dependency in alloy-app's Chart.yaml.
     alloy:
-      enabled: false
-    networkPolicy:
-      flavor: none
-    kyvernoPolicyExceptions:
       enabled: false
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -87,4 +70,12 @@ spec:
     name: alloy-logexporter-config
     valuesKey: values
     # Absent until observability-operator enables the feature on this installation.
+    optional: true
+  # The object store credentials are a separate Secret rather than part of the
+  # ConfigMap above: alloy-app takes `extraSecretEnv` as {name, value} pairs and
+  # base64-encodes them into a Secret it creates itself, so keeping them in the
+  # ConfigMap would mean plaintext credentials in a ConfigMap.
+  - kind: Secret
+    name: alloy-logexporter-secret
+    valuesKey: values
     optional: true

--- a/bases/collections/shared/base/kustomization.yaml
+++ b/bases/collections/shared/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - alloy-logexporter.yaml
   - app-admission-controller.yaml
   - app-exporter.yaml
   - app-operator.yaml


### PR DESCRIPTION
Deploys `alloy-logexporter` — the audit/Teleport log export pipeline for
giantswarm/giantswarm#37251 — to every management cluster, **rendering nothing**
until observability-operator enables it on a given installation.

Nothing changes on any installation on merge.

### How it works

```
OCIRepository  alloy-logexporter  -> chart `alloy`
ConfigMap      alloy-logexporter-defaults   { off }
HelmRelease    alloy-logexporter
  valuesFrom:
    1. alloy-logexporter-defaults           <- off by default, fail-safe
    2. alloy-logexporter-config  optional   <- observability-operator, wins
```

The release uses the `alloy` chart under a different release name, the same
one-chart-many-names arrangement observability-bundle uses for
alloy-logs/alloy-metrics/alloy-events. observability-operator enables an
installation by creating `alloy-logexporter-config`, which carries
`alloy.enabled: true`, the deployment shape and the Alloy config. That ConfigMap is
`optional` so this is valid before it exists, and if the operator never writes it
the defaults keep the release inert.

### Two details worth knowing before editing this file

**There is deliberately no `spec.values`.** Flux merges `valuesFrom` entries in
order and then lets inline values override all of them, so anything set inline —
including `alloy.enabled` — would permanently override the operator and the feature
could never be enabled. There is a comment in the file saying so.

**Turning the release into a no-op takes three keys, not one.** Helm drops a
subchart entirely when its condition is false, including its `_helpers.tpl`, and
alloy-app's own templates call `alloy.labels`/`alloy.chart` from the subchart. With
only `alloy.enabled: false` the release fails to template:

```
Error: template: alloy/templates/cilium-networkpolicy.yaml:8:8 ...
  error calling include: template: no template "alloy.chart" associated with template "gotpl"
```

so alloy-app's own templates are switched off too (`networkPolicy.flavor: none`
matches neither the cilium nor the kubernetes branch; `kyvernoPolicyExceptions`
off). Arguably alloy-app should not depend on subchart helpers in its own
templates — worth a follow-up there, but this works today without a chart release.

### Verification

- `kustomize build bases/collections/shared/base` renders.
- `helm template` of the published `alloy` chart using the **exact** defaults
  ConfigMap shipped here → **0 objects, no error**.
- The same chart with the operator's values → StatefulSet with 2 replicas, the
  `wal` volumeClaimTemplate, and `--stability.level=experimental` on the container,
  which is what the export pipeline needs.
