### PR TITLE
fix: apply shared stage patches last so the testing semver patch covers provider and addons apps

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -28,6 +28,10 @@ build-collections: $(KUSTOMIZE) ## Build every collection stage the way kustomiz
 	@echo "====> $@"
 	@rc=0; \
 	for dir in bases/collections/*/stages/*/; do \
+		if grep -qx 'kind: Component' "$$dir/kustomization.yaml"; then \
+			echo "skip  $$dir (Component, exercised via the provider stages)"; \
+			continue; \
+		fi; \
 		if $(KUSTOMIZE) build "$$dir" >/dev/null; then \
 			echo "ok    $$dir"; \
 		else \

--- a/bases/collections/capa/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/capa/stages/stable-testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable-testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/capa/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/capa/stages/stable-testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable-testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/capa/stages/stable/kustomization.yaml
+++ b/bases/collections/capa/stages/stable/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/capa/stages/stable/kustomization.yaml
+++ b/bases/collections/capa/stages/stable/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable
+resources:
+  - ../../../shared/base

--- a/bases/collections/capa/stages/staging/kustomization.yaml
+++ b/bases/collections/capa/stages/staging/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/staging
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/capa/stages/staging/kustomization.yaml
+++ b/bases/collections/capa/stages/staging/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/staging
+resources:
+  - ../../../shared/base

--- a/bases/collections/capa/stages/testing/kustomization.yaml
+++ b/bases/collections/capa/stages/testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/capa/stages/testing/kustomization.yaml
+++ b/bases/collections/capa/stages/testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/capz/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/capz/stages/stable-testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable-testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/capz/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/capz/stages/stable-testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable-testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/capz/stages/stable/kustomization.yaml
+++ b/bases/collections/capz/stages/stable/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/capz/stages/stable/kustomization.yaml
+++ b/bases/collections/capz/stages/stable/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable
+resources:
+  - ../../../shared/base

--- a/bases/collections/capz/stages/staging/kustomization.yaml
+++ b/bases/collections/capz/stages/staging/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/staging
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/capz/stages/staging/kustomization.yaml
+++ b/bases/collections/capz/stages/staging/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/staging
+resources:
+  - ../../../shared/base

--- a/bases/collections/capz/stages/testing/kustomization.yaml
+++ b/bases/collections/capz/stages/testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/capz/stages/testing/kustomization.yaml
+++ b/bases/collections/capz/stages/testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/cloud-director/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/cloud-director/stages/stable-testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable-testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/cloud-director/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/cloud-director/stages/stable-testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable-testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/cloud-director/stages/stable/kustomization.yaml
+++ b/bases/collections/cloud-director/stages/stable/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/cloud-director/stages/stable/kustomization.yaml
+++ b/bases/collections/cloud-director/stages/stable/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable
+resources:
+  - ../../../shared/base

--- a/bases/collections/cloud-director/stages/staging/kustomization.yaml
+++ b/bases/collections/cloud-director/stages/staging/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/staging
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/cloud-director/stages/staging/kustomization.yaml
+++ b/bases/collections/cloud-director/stages/staging/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/staging
+resources:
+  - ../../../shared/base

--- a/bases/collections/cloud-director/stages/testing/kustomization.yaml
+++ b/bases/collections/cloud-director/stages/testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/cloud-director/stages/testing/kustomization.yaml
+++ b/bases/collections/cloud-director/stages/testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/kamaji-addons/stages/testing/kustomization.yaml
+++ b/bases/collections/kamaji-addons/stages/testing/kustomization.yaml
@@ -1,3 +1,7 @@
+# Applied after ../../base below, so the shared testing-stage patches reach
+# every OCIRepository in this collection.
+components:
+  - ../../../shared/stages/testing
 patches:
   - target:
       kind: Konfiguration

--- a/bases/collections/proxmox-aws-addons/stages/testing/kustomization.yaml
+++ b/bases/collections/proxmox-aws-addons/stages/testing/kustomization.yaml
@@ -1,3 +1,7 @@
+# Applied after ../../base below, so the shared testing-stage patches reach
+# every OCIRepository in this collection.
+components:
+  - ../../../shared/stages/testing
 patches:
   - target:
       kind: Konfiguration

--- a/bases/collections/proxmox-vsphere-addons/stages/testing/kustomization.yaml
+++ b/bases/collections/proxmox-vsphere-addons/stages/testing/kustomization.yaml
@@ -1,3 +1,7 @@
+# Applied after ../../base below, so the shared testing-stage patches reach
+# every OCIRepository in this collection.
+components:
+  - ../../../shared/stages/testing
 patches:
   - target:
       kind: Konfiguration

--- a/bases/collections/proxmox/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/proxmox/stages/stable-testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable-testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/proxmox/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/proxmox/stages/stable-testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable-testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/proxmox/stages/stable/kustomization.yaml
+++ b/bases/collections/proxmox/stages/stable/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/proxmox/stages/stable/kustomization.yaml
+++ b/bases/collections/proxmox/stages/stable/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable
+resources:
+  - ../../../shared/base

--- a/bases/collections/proxmox/stages/staging/kustomization.yaml
+++ b/bases/collections/proxmox/stages/staging/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/staging
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/proxmox/stages/staging/kustomization.yaml
+++ b/bases/collections/proxmox/stages/staging/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/staging
+resources:
+  - ../../../shared/base

--- a/bases/collections/proxmox/stages/testing/kustomization.yaml
+++ b/bases/collections/proxmox/stages/testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/proxmox/stages/testing/kustomization.yaml
+++ b/bases/collections/proxmox/stages/testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/shared/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/shared/stages/stable-testing/kustomization.yaml
@@ -1,3 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# See shared/stages/testing/kustomization.yaml for why this is a Component.
+# Note: this stage deliberately keeps per-app semver patches only. The wildcard
+# "any RC or newer" patch lives in shared/stages/testing and must not apply here.
 patches:
   - target:
       kind: Konfiguration
@@ -14,5 +19,3 @@ patches:
       name: kyverno-policies-ux
       namespace: giantswarm
     path: semver-kyverno-policies-ux.yaml
-resources:
-  - ../../base

--- a/bases/collections/shared/stages/stable/kustomization.yaml
+++ b/bases/collections/shared/stages/stable/kustomization.yaml
@@ -1,8 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# See shared/stages/testing/kustomization.yaml for why this is a Component.
 patches:
   - target:
       kind: Konfiguration
       name: collection-konfiguration
       namespace: giantswarm
     patch: '[{"op": "add", "path": "/spec/targets/defaults/variables/-", "value": {"name": "stage", "value": "stable"}}]'
-resources:
-  - ../../base

--- a/bases/collections/shared/stages/staging/kustomization.yaml
+++ b/bases/collections/shared/stages/staging/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# See shared/stages/testing/kustomization.yaml for why this is a Component.
 patches:
   - target:
       kind: Konfiguration
@@ -9,5 +12,3 @@ patches:
       name: kyverno-policies-ux
       namespace: giantswarm
     path: semver-kyverno-policies-ux.yaml
-resources:
-  - ../../base

--- a/bases/collections/shared/stages/testing/kustomization.yaml
+++ b/bases/collections/shared/stages/testing/kustomization.yaml
@@ -1,3 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# A Component, not a base: its patches are applied into the caller's accumulator
+# at the position it is listed, so a provider stage can list it *after*
+# ../../base and have these patches also reach the provider-specific apps.
 patches:
   - target:
       kind: Konfiguration
@@ -10,5 +15,3 @@ patches:
       kind: OCIRepository
       namespace: giantswarm
     path: semver-rc-or-stable-patch.yaml
-resources:
-  - ../../base

--- a/bases/collections/vsphere-addons/stages/testing/kustomization.yaml
+++ b/bases/collections/vsphere-addons/stages/testing/kustomization.yaml
@@ -1,3 +1,7 @@
+# Applied after ../../base below, so the shared testing-stage patches reach
+# every OCIRepository in this collection.
+components:
+  - ../../../shared/stages/testing
 patches:
   - target:
       kind: Konfiguration

--- a/bases/collections/vsphere-aws-addons/stages/testing/kustomization.yaml
+++ b/bases/collections/vsphere-aws-addons/stages/testing/kustomization.yaml
@@ -1,3 +1,7 @@
+# Applied after ../../base below, so the shared testing-stage patches reach
+# every OCIRepository in this collection.
+components:
+  - ../../../shared/stages/testing
 patches:
   - target:
       kind: Konfiguration

--- a/bases/collections/vsphere/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/vsphere/stages/stable-testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable-testing
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/vsphere/stages/stable-testing/kustomization.yaml
+++ b/bases/collections/vsphere/stages/stable-testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable-testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/vsphere/stages/stable/kustomization.yaml
+++ b/bases/collections/vsphere/stages/stable/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/stable
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/vsphere/stages/stable/kustomization.yaml
+++ b/bases/collections/vsphere/stages/stable/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/stable
+resources:
+  - ../../../shared/base

--- a/bases/collections/vsphere/stages/staging/kustomization.yaml
+++ b/bases/collections/vsphere/stages/staging/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/staging
+patches: []
 resources:
   - ../../../shared/base

--- a/bases/collections/vsphere/stages/staging/kustomization.yaml
+++ b/bases/collections/vsphere/stages/staging/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/staging
+resources:
+  - ../../../shared/base

--- a/bases/collections/vsphere/stages/testing/kustomization.yaml
+++ b/bases/collections/vsphere/stages/testing/kustomization.yaml
@@ -1,5 +1,7 @@
+# Order matters: ../../base contributes the provider-specific apps, so the shared
+# stage Component has to be listed *after* it for its patches to reach them too.
 components:
   - ../../base
-patches: []
-resources:
   - ../../../shared/stages/testing
+resources:
+  - ../../../shared/base

--- a/bases/collections/vsphere/stages/testing/kustomization.yaml
+++ b/bases/collections/vsphere/stages/testing/kustomization.yaml
@@ -3,5 +3,6 @@
 components:
   - ../../base
   - ../../../shared/stages/testing
+patches: []
 resources:
   - ../../../shared/base


### PR DESCRIPTION
## Why

#689 replaced the per-app semver patches in `bases/collections/shared/stages/testing/` with one wildcard patch on `kind: OCIRepository`. It only took effect for part of each collection.

Kustomize accumulates a kustomization in a fixed order: `resources:` → `components:` → its own `patches:`. The provider stages had:

```yaml
components:
  - ../../base                       # provider apps land 2nd
patches: []
resources:
  - ../../../shared/stages/testing   # shared apps + patches run 1st
```

As a `resources:` entry, `shared/stages/testing` is its own build target: it accumulates `shared/base`, applies its patches, and hands a finished result upward. The provider apps are appended on top of that, so a patch defined in `shared/stages/<stage>` can never see them.

Measured on `main`, `capa/stages/testing` renders 57 OCIRepositories with **7 still on `semver: x.x.x`** — `aws-lb-controller-bundle`, `aws-resolver-rules-operator`, `aws-vpc-operator`, `capa-iam-operator`, `cluster-api-provider-aws`, `crossplane-fn-irsa`, `crossplane-fn-mcoidc`. Same for capz (5), vsphere (5), cloud-director (4) and proxmox (3). The addons collections never got the patch at all.

## What

Fix the layering rather than this one patch:

- `shared/stages/<stage>` becomes a patch-only `kind: Component`.
- Each provider stage pulls `shared/base` in via `resources:` and lists `../../base` **before** `../../../shared/stages/<stage>` in `components:`.

A Component has no accumulator of its own — its patches are applied into the caller's at the position it is listed, so they now run last, once every app is present. Addons testing stages reference the same Component.

`<provider>/base` has to stay a Component (its `patches/konfiguration.yaml` merges provider apps into the `collection-konfiguration` that comes from `shared/base`), which is why the shared side is the one that moves.

The payoff beyond this patch: **any future stage patch is a one-file change in `shared/stages/<stage>`** and reaches provider and addons apps by construction.

## Scope

The wildcard patch stays in `shared/stages/testing` only. `stable`, `staging` and `stable-testing` are untouched in effect — in particular `stable-testing` keeps its per-app `konfigure-operator` and `kyverno-policies-ux` patches and gains nothing else.

## Verification

`make build-collections` (pinned kustomize v5.6.0, deliberately no `--load-restrictor`) passes for all 36 collection stages.

Every stage rendered and diffed against `main`:

| stage | render vs `main` | OCIRepositories with `semverFilter` |
|---|---|---|
| `*/stages/testing` (10 collections) | differs, additions only | **all** (57/55/54/53/55 provider, 3/4/5/3/1 addons) |
| `*/stages/stable-testing` | **identical** | `konfigure-operator`, `kyverno-policies-ux` only |
| `*/stages/staging` | **identical** | `kyverno-policies-ux` only |
| `*/stages/stable` | **identical** | none |

The full rendered diff for `capa/stages/testing` is exactly the 7 apps above gaining `semver: '>=0.0.0-0'` + `semverFilter`, nothing else. The Konfiguration `stage` variable is present exactly once in every collection, addons included.

## Notes for review

- Component order in the provider stages is load-bearing — sorting `components:` alphabetically would silently reintroduce the bug. There is a comment on each file saying so.
- Addons stages reference `shared/stages/testing` directly, whose Konfiguration patch targets `collection-konfiguration`, a name they don't have (theirs are `<addons>-collection-konfiguration`). Kustomize silently ignores a target that matches nothing and its name selector is anchored, so it is a clean no-op — confirmed by the single `stage` variable in the output. Happy to split the OCIRepository patch into a nested Component instead if relying on that is unwelcome; the cost is that future stage patches then need adding in two places.
- `make build-collections` now skips the shared stage dirs: as Components they render empty, so building them was reporting `ok` for a no-op. They are still exercised through all 20 provider stage builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
