### PR TITLE
Run alloy-logexporter in the monitoring namespace

### DIFF
--- a/bases/collections/shared/base/alloy-logexporter.yaml
+++ b/bases/collections/shared/base/alloy-logexporter.yaml
@@ -49,8 +49,8 @@ spec:
       retries: 10
   interval: 5m
   releaseName: alloy-logexporter
-  storageNamespace: alloy-logexporter
-  targetNamespace: alloy-logexporter
+  storageNamespace: monitoring
+  targetNamespace: monitoring
   timeout: 10m
   upgrade:
     remediation:


### PR DESCRIPTION
Follow-up to #687. `alloy-logexporter` was the only entry in
`bases/collections/shared/base/` with a namespace of its own — that was an oversight
on my part. It belongs in `monitoring` with the rest of the observability platform.

| Namespace | Entries |
|---|---|
| `giantswarm` | ~30 platform operators |
| `monitoring` | grafana, observability-operator, observability-platform-api, prometheus-remotewrite, prometheus-rules, silence-operator, sloth, sloth-rules, oauth2-proxy, grafana-organizations |
| `tempo`, `org-giantswarm` | one each |
| ~~`alloy-logexporter`~~ | ~~only this one~~ |

`monitoring` already exists on every MC, so nothing new is created anywhere.
`install.createNamespace` stays, matching the other monitoring-targeting entries
(`observability-platform-api`, `prometheus-rules`, `sloth-rules`).

Nothing else in the entry changes: the release name, the defaults ConfigMap and the
three `valuesFrom` references are all namespace-independent, and the config ConfigMap
and Secret already live in `giantswarm` alongside the HelmRelease.

### One cleanup needed after this rolls out

Changing `storageNamespace` means helm-controller looks for the release in
`monitoring`, does not find it, and installs fresh. The `alloy-logexporter` namespace
that Helm created when #687 first rolled out is then orphaned — Helm does not remove a
namespace it created. It holds nothing but the release secrets:

```console
$ kubectl -n alloy-logexporter get all,cm,secret --no-headers | grep -v kube-root-ca
secret/sh.helm.release.v1.alloy-logexporter.v1   helm.sh/release.v1   1   4h
secret/sh.helm.release.v1.alloy-logexporter.v2   helm.sh/release.v1   1   2h
```

So per installation, **after** this has rolled out:

```bash
kubectl -n monitoring get secret -l owner=helm | grep alloy-logexporter   # confirm it moved
kubectl -n alloy-logexporter get all,cm,secret --no-headers | grep -v kube-root-ca
kubectl delete ns alloy-logexporter
```

Order matters — deleting before the rollout just makes helm-controller recreate it.

### Verification

`kustomize build bases/collections/shared/base` renders, and the resulting HelmRelease
still has no `spec.values` and all three `valuesFrom` references intact. The app stays
disabled by default, so no MC gains a workload from this.
