### PR TITLE
Ship a ReferenceGrant for the alloy-logexporter mirror backend

### DIFF
--- a/bases/collections/shared/base/alloy-logexporter.yaml
+++ b/bases/collections/shared/base/alloy-logexporter.yaml
@@ -90,7 +90,12 @@ spec:
 # failure mode. The mirror is fire-and-forget, so Envoy discards the response and a
 # missing grant would otherwise show up only as logs that never arrive.
 #
-# v1beta1 rather than v1: both are served, but v1beta1 is the storage version.
+# v1beta1 rather than v1: ReferenceGrant only gained a v1 in Gateway API v1.5.0, so
+# v1beta1 is the one version valid on every bundle an MC might have converged to —
+# and gateway-api-bundle floats on its own semver range, independently of this repo.
+# A resource the API server rejects fails the whole Kustomization, not just this
+# entry. Neither version is marked deprecated yet; move to v1 once the fleet's floor
+# is comfortably past v1.5.0.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:

--- a/bases/collections/shared/base/alloy-logexporter.yaml
+++ b/bases/collections/shared/base/alloy-logexporter.yaml
@@ -79,3 +79,29 @@ spec:
     name: alloy-logexporter-secret
     valuesKey: values
     optional: true
+---
+# Logs reach alloy-logexporter through an Envoy RequestMirror filter on Loki's
+# write route. That route is an HTTPRoute in `loki` and the backend is a Service in
+# `monitoring`, so Gateway API requires an explicit grant in the TARGET namespace —
+# without it the route reports ResolvedRefs=False and no traffic is mirrored.
+#
+# Not gated on the feature being enabled: a grant that permits a reference nobody
+# has made yet does nothing, and shipping it unconditionally removes a silent
+# failure mode. The mirror is fire-and-forget, so Envoy discards the response and a
+# missing grant would otherwise show up only as logs that never arrive.
+#
+# v1beta1 rather than v1: both are served, but v1beta1 is the storage version.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: loki-httproute-to-alloy-logexporter
+  namespace: monitoring
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: loki
+  to:
+  - group: ""
+    kind: Service
+    name: alloy-logexporter

--- a/bases/collections/shared/base/alloy-logexporter.yaml
+++ b/bases/collections/shared/base/alloy-logexporter.yaml
@@ -80,22 +80,10 @@ spec:
     valuesKey: values
     optional: true
 ---
-# Logs reach alloy-logexporter through an Envoy RequestMirror filter on Loki's
-# write route. That route is an HTTPRoute in `loki` and the backend is a Service in
-# `monitoring`, so Gateway API requires an explicit grant in the TARGET namespace —
-# without it the route reports ResolvedRefs=False and no traffic is mirrored.
+# Lets Loki's write HTTPRoute mirror requests to alloy-logexporter in `monitoring`.
+# Ungated: the grant does nothing until the mirror filter is enabled.
 #
-# Not gated on the feature being enabled: a grant that permits a reference nobody
-# has made yet does nothing, and shipping it unconditionally removes a silent
-# failure mode. The mirror is fire-and-forget, so Envoy discards the response and a
-# missing grant would otherwise show up only as logs that never arrive.
-#
-# v1beta1 rather than v1: ReferenceGrant only gained a v1 in Gateway API v1.5.0, so
-# v1beta1 is the one version valid on every bundle an MC might have converged to —
-# and gateway-api-bundle floats on its own semver range, independently of this repo.
-# A resource the API server rejects fails the whole Kustomization, not just this
-# entry. Neither version is marked deprecated yet; move to v1 once the fleet's floor
-# is comfortably past v1.5.0.
+# v1beta1: v1 needs Gateway API >= v1.5.0.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:


### PR DESCRIPTION
Adds a `ReferenceGrant` to the existing `alloy-logexporter` collections entry. Part of [giantswarm/giantswarm#37251](https://github.com/giantswarm/giantswarm/issues/37251).

Logs reach `alloy-logexporter` through an Envoy `RequestMirror` filter on Loki's write route ([loki-app#539](https://github.com/giantswarm/loki-app/pull/539), [observability-platform-api#89](https://github.com/giantswarm/observability-platform-api/pull/89)). That route is an HTTPRoute in `loki` and the backend is a Service in `monitoring`, so Gateway API requires an explicit grant in the target namespace — without it the route reports `ResolvedRefs=False` and nothing is mirrored.

Unlike the rest of the entry it is not gated on the feature being enabled: a grant permitting a reference nobody has made yet does nothing, and always having it removes a silent failure mode. The mirror is fire-and-forget — Envoy discards the response — so a missing grant would surface only as logs that never arrive, which is how the earlier spike found it.

### Why `v1beta1` and not `v1`

`ReferenceGrant` only gained a `v1` in **Gateway API v1.5.0** — v1.3.0 and v1.4.0 ship `v1beta1` alone. Every MC I could reach is on bundle v1.5.1 (26 of 33 contexts, all identical), so `v1` would work today, but `gateway-api-bundle` floats on its own semver range independently of this repo, so nothing here can assume a floor. A resource the API server rejects fails the whole Kustomization rather than just this entry, and `v1beta1` is the one version valid on both sides of the v1.5.0 boundary. It also matches the two grants already in the fleet, whose `managedFields` show `v1beta1`.

Neither version is flagged `deprecated`, so there is no warning to act on yet; the comment says to move to `v1` once the fleet floor is comfortably past v1.5.0. (Note `kubectl get -o yaml` prints `v1` for these objects regardless of what was applied — discovery prefers it for display.)

Verified on graveler: with this grant applied and the mirror filter added by hand, the route stayed `Accepted`/`ResolvedRefs` True and real audit logs reached object storage. Both were reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)