### PR TITLE
Remove the alloy-logexporter ReferenceGrant from collections

### DIFF
--- a/bases/collections/shared/base/alloy-logexporter.yaml
+++ b/bases/collections/shared/base/alloy-logexporter.yaml
@@ -79,22 +79,3 @@ spec:
     name: alloy-logexporter-secret
     valuesKey: values
     optional: true
----
-# Lets Loki's write HTTPRoute mirror requests to alloy-logexporter in `monitoring`.
-# Ungated: the grant does nothing until the mirror filter is enabled.
-#
-# v1beta1: v1 needs Gateway API >= v1.5.0.
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: ReferenceGrant
-metadata:
-  name: loki-httproute-to-alloy-logexporter
-  namespace: monitoring
-spec:
-  from:
-  - group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    namespace: loki
-  to:
-  - group: ""
-    kind: Service
-    name: alloy-logexporter


### PR DESCRIPTION
Reverts the `ReferenceGrant` added in #695. It breaks creation of new management clusters.

The grant is a Gateway API CR, but `collections` is the Kustomization that installs
`gateway-api-bundle`, so on a fresh MC the CRD does not exist yet:

```
ReferenceGrant/giantswarm/loki-httproute-to-alloy-logexporter dry-run failed:
no matches for kind "ReferenceGrant" in version "gateway.networking.k8s.io/v1beta1"
```

kustomize-controller dry-runs the whole directory as one set, so this blocks every other manifest —
including the HelmRelease that would create the CRD. It never converges, and mc-bootstrap times out
waiting for `organization-operator`.

The grant moves into the loki chart, gated on the mirror value: giantswarm/loki-app#539. A HelmRelease
retries on its own, so it simply waits for the CRD. Nothing is lost meanwhile — the mirror is disabled
everywhere, so no route references the backend yet.

`make build-collections`: 44 stages ok. The file is back to its pre-#695 blob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)