### PR TITLE
feat: add extras/agent-platform base for the renamed chart

### DIFF
--- a/bases/apps-to-teams-mapping/configmap.yaml
+++ b/bases/apps-to-teams-mapping/configmap.yaml
@@ -8,6 +8,10 @@ metadata:
 data:
   agent-sandbox: bumblebee
   agentgateway: bumblebee
+  agent-platform-connectivity: bumblebee
+  agent-platform-mcps: bumblebee
+  agent-platform: bumblebee
+  # Deprecated chart names, kept until no installation runs an old-name release.
   agentic-platform-connectivity: bumblebee
   agentic-platform-mcps: bumblebee
   agentic-platform: bumblebee

--- a/extras/agent-platform/README.md
+++ b/extras/agent-platform/README.md
@@ -1,0 +1,189 @@
+# Agent Platform Extras
+
+This directory contains the Flux resources required to deploy the
+`agent-platform` meta-package on a Giant Swarm management cluster.
+
+## Overview
+
+`agent-platform` (chart >=2.6.0; formerly `agentic-platform`) is a **meta-package (app-of-apps)**:
+it no longer bundles sub-charts, but renders each component as its own Flux
+`OCIRepository` + `HelmRelease` (version ranges resolved at reconcile time, so
+component releases roll forward with no PR). Components include muster (MCP
+aggregator / OAuth resource server), valkey (OAuth session storage),
+agentgateway (MCP data plane), kagent, klaus-gateway, agent-sandbox, and the
+`agent-platform-connectivity` chart that owns the wiring (public `HTTPRoute`,
+`Gateway`, `AgentgatewayParameters`, CiliumNetworkPolicies).
+
+On Giant Swarm clusters the meta-package's `HelmRelease` sets:
+
+```yaml
+spec:
+  values:
+    gitops:
+      namespace: flux-giantswarm      # render the child Flux CRs here — exempt
+      targetNamespace: agent-platform  #   from flux-multi-tenancy; workloads here
+```
+
+The child `HelmRelease`s are created in `flux-giantswarm` (the
+flux-multi-tenancy Kyverno policy rejects HelmReleases lacking
+`serviceAccountName` outside `flux-giantswarm`/`giantswarm`/`monitoring`) and
+install their workloads into `agent-platform`.
+
+## Prerequisites
+
+CRDs are **app-owned** (chart >= v1.10.0): each component ships its own CRDs in
+the chart's `crds/` directory and the meta-package sets `crds: CreateReplace`
+on the component, so the CRDs are installed and upgraded with the component
+itself. There is no separate CRD bundle — the previous
+`agent-platform-crds` `HelmRelease` was retired on 2026-06-22 (its CRDs carry
+`helm.sh/resource-policy: keep`, so removing the bundle leaves the live CRDs and
+their CRs untouched). CR-before-CRD ordering is handled inside the child
+releases: `agent-platform-connectivity` and `agent-platform-mcps`
+`dependsOn` the CRD-owning components (`agentgateway`, `kagent`), so a CR is
+never applied before its CRD exists. No manual `helm install` for CRDs is
+required, and any standalone references to
+`giantswarm/muster/v*/helm/muster/crds/*.yaml` should be removed from the
+cluster's `crds/kustomization.yaml`.
+
+The Gateway API v1 CRDs and a Gateway to attach muster's public `HTTPRoute` to
+(e.g. `envoy-gateway-system/giantswarm-default`) remain cluster prerequisites.
+
+## Configuration
+
+Configuration is supplied via two ConfigMaps merged onto the HelmRelease:
+
+1. **shared-configs** rendered into `agent-platform-konfiguration` by the
+   bundled `Konfiguration` resource. Requires a matching `agent-platform`
+   template in `giantswarm-config` that renders values under the umbrella's
+   `muster:` subchart prefix (e.g. `muster.muster.oauth.server.baseUrl`).
+2. **per-cluster overrides** via a `agent-platform-user-values` ConfigMap
+   appended by the consumer kustomization (see usage below).
+
+Required per-cluster fields (template-time fail-guards reject install
+otherwise):
+
+| Field | Notes |
+|---|---|
+| `muster.muster.oauth.server.baseUrl` | Public muster URL (HTTPS) |
+| `muster.muster.oauth.server.dex.issuerUrl` | Dex issuer on this cluster |
+| `muster.muster.oauth.server.dex.clientId` | OAuth client pre-registered in Dex |
+| `muster.muster.oauth.server.existingSecret` | Secret with `dex-client-secret`, `registration-token`, `oauth-encryption-key`, `valkey-password` |
+| `muster.muster.gatewayAPI.httpRoute.parentRefs` | Public Gateway to attach to (e.g. `envoy-gateway-system/giantswarm-default`) |
+| `muster.muster.gatewayAPI.httpRoute.hostnames` | Public hostnames |
+| `valkey.valkey.auth.usersExistingSecret` | Conventionally the same Secret as above (key `valkey-password`) |
+
+## Secrets Required
+
+Before deployment, ensure this Secret exists in the `muster` namespace
+(conventionally a single Secret referenced from both `muster.muster.oauth.server.existingSecret`
+and `valkey.valkey.auth.usersExistingSecret`):
+
+```bash
+kubectl create secret generic agent-platform-secrets \
+  --namespace agent-platform \
+  --from-literal=dex-client-secret=<dex-client-secret> \
+  --from-literal=registration-token=$(openssl rand -hex 32) \
+  --from-literal=oauth-encryption-key=$(openssl rand -base64 32) \
+  --from-literal=valkey-password=$(openssl rand -base64 32)
+```
+
+## Usage
+
+To deploy on a management cluster, reference this directory from
+`giantswarm-management-clusters`:
+
+```yaml
+# management-clusters/<mc>/extras/agent-platform/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/giantswarm/management-cluster-bases//extras/agent-platform?ref=main
+  - agent-platform-secrets.enc.yaml
+  - ./mcpservers
+  - ./secrets
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: agent-platform-user-values
+    namespace: flux-giantswarm
+    files:
+      - values=user-values.yaml
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/valuesFrom/-
+        value:
+          kind: ConfigMap
+          name: agent-platform-user-values
+          valuesKey: values
+    target:
+      kind: HelmRelease
+      name: agent-platform
+```
+
+## Dependencies
+
+- dex-app >= 2.1.5 (for muster static client support)
+- Gateway API v1 CRDs + a public Gateway to attach muster's HTTPRoute to
+- shared-configs with an `agent-platform` app template (renders values
+  under the `muster:` umbrella prefix)
+
+## Deploying additional charts into `kagent`
+
+This base also provisions a `kagent-flux` ServiceAccount in the `kagent`
+namespace (`service-account.yaml`), bound to the built-in `cluster-admin`
+`ClusterRole` via a namespace-scoped `RoleBinding` — i.e. full control of all
+resources **within `kagent`** only.
+
+The `kagent` namespace itself is **not** created here — it is owned by the
+`agent-platform-connectivity` component (Helm). Flux applies the SA/RoleBinding
+once that namespace exists, retrying on its interval until then.
+
+Use it to deploy additional agent-platform charts as `HelmRelease`s living in
+the `kagent` namespace. Unlike the umbrella (which lives in the
+policy-exempt `flux-giantswarm`), a `HelmRelease` in `kagent` is subject to the
+`flux-multi-tenancy` Kyverno policy, so it **must** set `serviceAccountName` and
+target its own namespace:
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: <chart>
+  namespace: kagent
+spec:
+  serviceAccountName: kagent-flux   # required by flux-multi-tenancy Kyverno policy
+  targetNamespace: kagent           # must be local (targetNamespaceMustBeLocal rule)
+  ...
+```
+
+Because the binding is namespace-scoped, such charts can only create namespaced
+resources in `kagent`; cluster-scoped resources (CRDs, ClusterRoles) are denied.
+
+## Creating agents (tenant self-service)
+
+Tenants create agents with the generic
+[`agent` chart](https://github.com/giantswarm/agent) (one Helm release = one
+agent), typically as a `HelmRelease` in `kagent` using the `kagent-flux`
+ServiceAccount described above. The admin-owned resources the chart relies on
+(see the [creating-agents PRD](https://github.com/giantswarm/bumblebee-plans/blob/main/creating-agents/PRD.md))
+are all rendered by the umbrella — **no extra CRs need to be applied via
+GitOps**:
+
+- **`ModelConfig` + LLM credentials**: the kagent component renders
+  `default-model-config` and creates the `kagent-anthropic` Secret in the
+  `kagent` namespace from `kagent.providers.anthropic.apiKey`, which is
+  SOPS-encrypted per cluster in giantswarm-configs under
+  `installations/<mc>/apps/agent-platform/`. Rotate the key there; additional
+  catalog entries go in the `agents.models` values.
+- **Shared muster `RemoteMCPServer`**: the `agent-platform-connectivity`
+  component renders a `RemoteMCPServer` named `muster` in the
+  `agent-platform` namespace with `allowedNamespaces: {from: All}` — the
+  server the agent chart's `serverRef` defaults to. Rendered whenever the
+  kagent and muster components are enabled; the name/namespace pair is fixed
+  (it is the platform contract the agent chart depends on).
+
+## Related
+
+- [agent-platform chart](https://github.com/giantswarm/agent-platform)
+- [Muster MC Deployment Concept](https://github.com/giantswarm/muster/blob/main/docs/concepts/mc-deployment.md)

--- a/extras/agent-platform/helm-release.yaml
+++ b/extras/agent-platform/helm-release.yaml
@@ -1,0 +1,59 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agent-platform
+  namespace: flux-giantswarm
+  labels:
+    # Owning team for Flux-failure alert routing and Backstage catalog ownership.
+    # The umbrella HelmRelease is created by this base (not rendered by the chart),
+    # so the chart's labels.common helper never stamps it — set it explicitly here.
+    application.giantswarm.io/team: bumblebee
+spec:
+  # Explicitly set release name to avoid Flux generating a prefixed name
+  # when targetNamespace differs from HelmRelease namespace
+  releaseName: agent-platform
+  # CRDs are app-owned: each component ships its own crds/ and the meta-package
+  # sets crds: CreateReplace per component (chart >=1.10.0). CR-before-CRD
+  # ordering is handled inside each child release (connectivity/mcps dependsOn
+  # the CRD-owning component), so the meta-package needs no CRD-bundle dependsOn.
+  chartRef:
+    kind: OCIRepository
+    name: agent-platform
+    namespace: flux-giantswarm
+  install:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  interval: 10m
+  targetNamespace: agent-platform
+  timeout: 20m
+  upgrade:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  # GitOps topology for the meta-package. The chart renders each
+  # component as its own OCIRepository + HelmRelease. Create those Flux objects in
+  # flux-giantswarm (exempt from the flux-multi-tenancy Kyverno policy, which would
+  # otherwise reject child HelmReleases for missing serviceAccountName) and route
+  # the workloads to the agent-platform namespace. Each component owns its CRDs
+  # (crds: CreateReplace); there is no separate CRD bundle to delegate to.
+  values:
+    gitops:
+      namespace: flux-giantswarm
+      targetNamespace: agent-platform
+  valuesFrom:
+    # ConfigMap rendered by Konfiguration from shared-configs template.
+    # NOTE: requires a matching `agent-platform` template in giantswarm-config
+    # that renders values under the umbrella's `muster:` subchart prefix
+    # (e.g. muster.muster.oauth.server.baseUrl, not oauth.server.baseUrl).
+    - kind: ConfigMap
+      name: agent-platform-konfiguration
+      valuesKey: configmap-values.yaml
+    # Secret rendered by Konfiguration from the shared-configs secret-values template.
+    # Per-cluster overrides (e.g. kagent.providers.anthropic.apiKey) are
+    # SOPS-encrypted in giantswarm-configs under installations/<cluster>/apps/agent-platform/.
+    # optional: true so clusters without a secret override still reconcile.
+    - kind: Secret
+      name: agent-platform-konfiguration
+      valuesKey: secret-values.yaml
+      optional: true

--- a/extras/agent-platform/konfiguration.yaml
+++ b/extras/agent-platform/konfiguration.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: konfigure.giantswarm.io/v1alpha1
+kind: Konfiguration
+metadata:
+  name: agent-platform-konfiguration
+  namespace: flux-giantswarm
+spec:
+  targets:
+    schema:
+      reference:
+        name: management-cluster-configuration
+        namespace: giantswarm
+    defaults:
+      variables:
+        - name: installation
+          value: "${cluster_name}"
+    iterations:
+      agent-platform:
+        variables:
+          - name: app
+            value: agent-platform
+          - name: team
+            value: bumblebee
+  destination:
+    namespace: flux-giantswarm
+    naming:
+      suffix: konfiguration
+  reconciliation:
+    interval: 1m
+    retryInterval: 10s
+    suspend: false
+  sources:
+    flux:
+      gitRepository:
+        name: "giantswarm-config"
+        namespace: "flux-giantswarm"

--- a/extras/agent-platform/kustomization.yaml
+++ b/extras/agent-platform/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./namespace.yaml
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./konfiguration.yaml
+  - ./service-account.yaml

--- a/extras/agent-platform/namespace.yaml
+++ b/extras/agent-platform/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agent-platform

--- a/extras/agent-platform/oci-repository.yaml
+++ b/extras/agent-platform/oci-repository.yaml
@@ -1,0 +1,17 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agent-platform
+  namespace: flux-giantswarm
+  labels:
+    # Owning team for Flux-failure alert routing and Backstage catalog ownership.
+    application.giantswarm.io/team: bumblebee
+spec:
+  interval: 10m
+  url: oci://gsoci.azurecr.io/charts/giantswarm/agent-platform
+  ref:
+    # Floor at 2.6.0, the first release published under the agent-platform chart
+    # name (the meta-package / app-of-apps era started at 1.5.x under the old
+    # agentic-platform name). Earlier releases only exist at the old OCI path.
+    semver: ">=2.6.0"
+  provider: generic

--- a/extras/agent-platform/service-account.yaml
+++ b/extras/agent-platform/service-account.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kagent-flux
+  namespace: kagent
+  labels:
+    application.giantswarm.io/team: bumblebee
+---
+# Namespace-scoped admin: a RoleBinding to the built-in cluster-admin ClusterRole
+# grants full control of ALL resources (including custom resources) within the
+# kagent namespace only. Used by Flux (spec.serviceAccountName: kagent-flux) to
+# deploy additional agent-platform HelmReleases into this namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kagent-flux
+  namespace: kagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kagent-flux
+    namespace: kagent


### PR DESCRIPTION
## Problem

The agent-platform charts are being renamed from agentic-platform (giantswarm/giantswarm#36869, Phase 2). All 12 installations pull `extras/agentic-platform` from this repo at `?ref=main`, so editing that directory in place would cut over the whole fleet at once.

## Change

- Adds `extras/agent-platform/` as a parallel base: Namespace/OCIRepository/HelmRelease/Konfiguration all named `agent-platform`, chart URL `oci://gsoci.azurecr.io/charts/giantswarm/agent-platform` with semver floor `>=2.6.0` (the first new-name release; giantswarm/agent-platform#218).
- Adds `agent-platform{,-connectivity,-mcps}: bumblebee` to apps-to-teams-mapping, keeping the old keys until no installation runs an old-name release.
- `extras/agentic-platform/` is untouched; installations flip their remote-base URL one at a time and the old directory is deleted once nothing references it.

Do not merge before agent-platform 2.6.0 and the matching `shared-configs` `default/apps/agent-platform/` templates exist, since the Konfiguration app key `agent-platform` must resolve there.
