### PR TITLE
fix: lower agent-platform OCIRepository semver floor to 2.5.5

### DIFF
--- a/extras/agent-platform/README.md
+++ b/extras/agent-platform/README.md
@@ -5,7 +5,7 @@ This directory contains the Flux resources required to deploy the
 
 ## Overview
 
-`agent-platform` (chart >=2.6.0; formerly `agentic-platform`) is a **meta-package (app-of-apps)**:
+`agent-platform` (chart >=2.5.5; formerly `agentic-platform`) is a **meta-package (app-of-apps)**:
 it no longer bundles sub-charts, but renders each component as its own Flux
 `OCIRepository` + `HelmRelease` (version ranges resolved at reconcile time, so
 component releases roll forward with no PR). Components include muster (MCP

--- a/extras/agent-platform/oci-repository.yaml
+++ b/extras/agent-platform/oci-repository.yaml
@@ -10,8 +10,7 @@ spec:
   interval: 10m
   url: oci://gsoci.azurecr.io/charts/giantswarm/agent-platform
   ref:
-    # Floor at 2.6.0, the first release published under the agent-platform chart
-    # name (the meta-package / app-of-apps era started at 1.5.x under the old
-    # agentic-platform name). Earlier releases only exist at the old OCI path.
-    semver: ">=2.6.0"
+    # Floor at 2.5.5, the first release published under the agent-platform chart
+    # name. Earlier releases only exist at the old OCI path.
+    semver: ">=2.5.5"
   provider: generic


### PR DESCRIPTION
## Problem
The `extras/agent-platform` base floors the OCIRepository at `>=2.6.0`, but the rename release was auto-tagged v2.5.5 (refactor commit, patch bump). The floor matches no published version, so the base cannot resolve a chart.

## Change
Lower the floor to `>=2.5.5`, the first release published under the `agent-platform` chart name. Adjust the README claim to match.