### PR TITLE
feat(alerting-config): add the alerting-config extras base

### DIFF
--- a/extras/alerting-config/helm-release.yaml
+++ b/extras/alerting-config/helm-release.yaml
@@ -1,0 +1,34 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alerting-config
+  namespace: flux-giantswarm
+  labels:
+    application.giantswarm.io/team: atlas
+spec:
+  releaseName: alerting-config
+  chartRef:
+    kind: OCIRepository
+    name: alerting-config
+    namespace: flux-giantswarm
+  install:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  interval: 10m
+  storageNamespace: monitoring
+  targetNamespace: monitoring
+  timeout: 10m
+  upgrade:
+    remediation:
+      retries: 10
+      remediateLastFailure: false
+  valuesFrom:
+    # Rendered by the Konfiguration from the shared-configs template
+    - kind: ConfigMap
+      name: alerting-config-konfiguration
+      valuesKey: configmap-values.yaml
+    # Per-installation Slack, PagerDuty and Cronitor credentials
+    - kind: Secret
+      name: alerting-config-konfiguration
+      valuesKey: secret-values.yaml

--- a/extras/alerting-config/konfiguration.yaml
+++ b/extras/alerting-config/konfiguration.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: konfigure.giantswarm.io/v1alpha1
+kind: Konfiguration
+metadata:
+  name: alerting-config-konfiguration
+  namespace: flux-giantswarm
+spec:
+  targets:
+    schema:
+      reference:
+        name: management-cluster-configuration
+        namespace: giantswarm
+    defaults:
+      variables:
+        - name: installation
+          value: "${cluster_name}"
+    iterations:
+      alerting-config:
+        variables:
+          - name: app
+            value: alerting-config
+          - name: team
+            value: atlas
+  destination:
+    namespace: flux-giantswarm
+    naming:
+      suffix: konfiguration
+  reconciliation:
+    interval: 1m
+    retryInterval: 10s
+    suspend: false
+  sources:
+    flux:
+      gitRepository:
+        name: "giantswarm-config"
+        namespace: "flux-giantswarm"

--- a/extras/alerting-config/kustomization.yaml
+++ b/extras/alerting-config/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./konfiguration.yaml

--- a/extras/alerting-config/oci-repository.yaml
+++ b/extras/alerting-config/oci-repository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: alerting-config
+  namespace: flux-giantswarm
+  labels:
+    application.giantswarm.io/team: atlas
+spec:
+  interval: 10m
+  url: oci://gsoci.azurecr.io/charts/giantswarm/alerting-config
+  ref:
+    semver: ">=0.0.0"
+  provider: generic


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/37438

### What this PR does / why we need it

Giant Swarm's Alertmanager configuration — team Slack channels, the EU PagerDuty endpoint, ~12KB of routing — currently lives in `helm/observability-operator/files/alertmanager/` in a **public** repository. It is moving into the private `alerting-config` app.

The operator already reconciles any Secret labelled `observability.giantswarm.io/kind: alertmanager-config` in any namespace, so no operator change is needed: the configuration lifts out as a chart that ships only that Secret, and the operator picks it up and pushes it to Mimir Alertmanager.

This adds the deployment base for that app. Shaped after `extras/mcp-prometheus`:

- `OCIRepository` → `oci://gsoci.azurecr.io/charts/giantswarm/alerting-config`
- `HelmRelease` targeting `monitoring`
- `Konfiguration` rendering **both** a ConfigMap and a Secret — unlike mcp-prometheus, this app carries per-installation Slack, PagerDuty and Cronitor credentials alongside the installation metadata (`managementCluster.name`, `managementCluster.pipeline`, `alerting.grafanaAddress`)

Nothing references this base yet; a follow-up in `giantswarm-management-clusters` wires it into `glean` as a canary, and the fleet follows once it has soaked. The chart is not published yet either, so the `OCIRepository` will not resolve until the first release lands.

No `dependsOn` on `observability-operator` deliberately: the operator's validating webhook is `failurePolicy: Fail`, so if it is not serving the Secret is rejected and Flux retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)