### PR TITLE
feat(backstage): add the login provider extra scopes fragment

### DIFF
--- a/extras/backstage/main/shared-config.yaml
+++ b/extras/backstage/main/shared-config.yaml
@@ -27,6 +27,21 @@ data:
         - giantswarm-ad:giantswarm-admins
         - giantswarm-github:giantswarm:giantswarm-admins
 
+      auth:
+        # Scopes every Backstage login provider requests on top of the fixed
+        # `openid profile email groups offline_access` set. The portal compiles
+        # in no default, so an instance that omits these silently loses both:
+        # without `federated:id` the sign-in resolver stops resolving users
+        # through the giantswarm-ad and giantswarm-github connectors and falls
+        # back to the email of the token, and without the cross-client audience
+        # scope every service that trusts the `dex-k8s-authenticator` audience
+        # (muster, and so the AI chat and the Muster UI) rejects the token the
+        # portal forwards to it. Both are Dex-specific: an instance on another
+        # issuer must not include this fragment.
+        extraScopes:
+          - federated:id
+          - audience:server:client_id:dex-k8s-authenticator
+
       catalog:
         orphanStrategy: delete
         orphanProviderStrategy: delete


### PR DESCRIPTION
## Problem

Backstage compiles in the Dex-specific login provider scopes today, `federated:id` and the cross-client `audience:server:client_id:dex-k8s-authenticator`. giantswarm/backstage#2115 removes those defaults so an instance can run against Keycloak or Entra ID, which reject both. Every Dex instance must then name them itself, and four instances would each hold their own copy.

## Change

Adds an `auth.extraScopes` fragment to the Backstage shared config, so the instances include one fleet-wide list. Inert on its own: nothing reads the fragment until each instance adds the `$include`.

Merge this before the per-instance PRs, or their `$include` has no target. Order: this PR, then the instance configs, then giantswarm/backstage#2115, then a chart bump per instance.