### PR TITLE
Remove agent-platform entries from configmap.yaml

### DIFF
--- a/bases/apps-to-teams-mapping/configmap.yaml
+++ b/bases/apps-to-teams-mapping/configmap.yaml
@@ -14,9 +14,6 @@ data:
   agent: bumblebee
   agentgateway: bumblebee
   ailefroide-app: chapter-se
-  agent-platform-connectivity: bumblebee
-  agent-platform-mcps: bumblebee
-  agent-platform: bumblebee
   alertmanager-to-github: atlas
   alloy-podlogs-crds: atlas
   alloy: atlas


### PR DESCRIPTION
Removed agent-platform connectivity entries from configmap.

## Some hints on changes to this repository

### Public information only

This is a public repository. The content and commit history is visible to everyone.

Do not provide any **customer-specific details**. Use the customer's repository for that.

### Descriptive PR title

Please write a descriptive pull request title. In this repo we don't maintain a changelog file, so the PR title (becoming the commit message after squash-merge) is the main information to understand a change in retrospect.
